### PR TITLE
Add `--set-as-main` flag support to repository bumper — `wazuh-dashboard-notifications`

### DIFF
--- a/.github/workflows/5_builderpackage_notifications_plugin.yml
+++ b/.github/workflows/5_builderpackage_notifications_plugin.yml
@@ -22,13 +22,13 @@ on:
         required: true
         type: string
         description: Git reference (branch, tag, or commit SHA) to build from.
-        default: 5.0.0
+        default: main
   workflow_dispatch:
     inputs:
       reference:
         required: true
         type: string
-        default: 5.0.0
+        default: main
         description: Git reference (branch, tag, or commit SHA) to build from.
 
 jobs:

--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -22,6 +22,11 @@ on:
         description: 'Optional identifier for the run'
         required: false
         type: string
+      set_as_main:
+        description: "Enable main branch mode: bump version values only, keep branch references pointing to main"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   bump:
@@ -74,6 +79,7 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           STAGE: ${{ inputs.stage }}
+          SET_AS_MAIN: ${{ inputs.set_as_main }}
         run: |
           script_params=""
           version=${{ env.VERSION }}
@@ -84,6 +90,11 @@ jobs:
             script_params="--version ${version} --stage ${stage}"
           elif [[ -z "$version" && -n "$stage" ]]; then
             script_params="--stage ${stage}"
+          fi
+
+          set_as_main=${{ env.SET_AS_MAIN }}
+          if [[ "$set_as_main" == "true" ]]; then
+            script_params="${script_params} --set-as-main"
           fi
 
           issue_number=$(echo "${{ inputs.issue-link }}" | awk -F'/' '{print $NF}')
@@ -100,7 +111,18 @@ jobs:
           echo "Running bump script"
           bash ${{ env.BUMP_SCRIPT_PATH }} ${{ steps.vars.outputs.script_params }}
 
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if git diff --quiet; then
+            echo "No changes detected; skipping PR creation."
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Commit and push changes
+        if: steps.check_changes.outputs.has_changes == 'true'
         run: |
           git add .
           git commit -m "feat: bump ${{ github.ref_name }}"
@@ -108,6 +130,7 @@ jobs:
 
       - name: Create pull request
         id: create_pr
+        if: steps.check_changes.outputs.has_changes == 'true'
         run: |
           gh auth setup-git
           PR_URL=$(gh pr create \
@@ -120,6 +143,7 @@ jobs:
           echo "pull_request_url=${PR_URL}" >> $GITHUB_OUTPUT
 
       - name: Merge pull request
+        if: steps.check_changes.outputs.has_changes == 'true'
         run: |
           gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge
 
@@ -127,6 +151,6 @@ jobs:
         run: |
           echo "Bump complete."
           echo "Branch: ${{ steps.vars.outputs.branch_name }}"
-          echo "PR: https://github.com/${{ github.repository }}/pull/${{ steps.create_pr.outputs.pull_request_number }}"
+          echo "PR: ${{ steps.create_pr.outputs.pull_request_url || 'N/A (no changes)' }}"
           echo "Bumper scripts logs:"
           cat ${BUMP_LOG_PATH}/repository_bumper*log

--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -151,6 +151,10 @@ jobs:
         run: |
           echo "Bump complete."
           echo "Branch: ${{ steps.vars.outputs.branch_name }}"
-          echo "PR: ${{ steps.create_pr.outputs.pull_request_url || 'N/A (no changes)' }}"
+          if [[ "${{ steps.check_changes.outputs.has_changes }}" == "true" ]]; then
+             echo "PR: ${{ steps.create_pr.outputs.pull_request_url }}"
+          else
+             echo "No file changes from bumper (no PR created)."
+          fi
           echo "Bumper scripts logs:"
           cat ${BUMP_LOG_PATH}/repository_bumper*log

--- a/tools/README.md
+++ b/tools/README.md
@@ -7,7 +7,7 @@ This script automates the process of updating the version and stage in the Wazuh
 ### Usage
 
 ```bash
-./repository_bumper.sh --version VERSION --stage STAGE [--tag] [--help]
+./repository_bumper.sh --version VERSION --stage STAGE [--tag] [--set-as-main] [--help]
 ```
 
 #### Parameters
@@ -23,6 +23,9 @@ This script automates the process of updating the version and stage in the Wazuh
 - `--tag`
   Generate a tag version format.
 
+- `--set-as-main`
+  Enable main branch mode: bump version values but keep branch references pointing to `main`.
+
 - `--help`
   Shows help and exits.
 
@@ -31,6 +34,7 @@ This script automates the process of updating the version and stage in the Wazuh
 ```bash
 ./repository_bumper.sh --version 5.0.0 --stage alpha0
 ./repository_bumper.sh --version 5.0.0 --stage beta1
+./repository_bumper.sh --version 5.1.0 --stage alpha0 --set-as-main
 ./repository_bumper.sh --tag --stage alpha1
 ./repository_bumper.sh --tag
 ```
@@ -47,7 +51,10 @@ This script automates the process of updating the version and stage in the Wazuh
    - `package.json`: Changes the `version` and `revision` fields inside the `wazuh` object.
    - `.github/workflows/5_builderpackage_notifications_plugin.yml`: Updates the default value of the `reference` input.
    - `CHANGELOG.md`: Inserts or updates a changelog entry.
-5. **Logs all actions** to a log file in the `tools` directory.
+5. **Handles branch reference replacements**:
+   - If `--set-as-main` is used, branch references to `main` are preserved.
+   - Otherwise, `main` references in supported workflow fields are replaced with the target version.
+6. **Logs all actions** to a log file in the `tools` directory.
 
 ### Notes
 
@@ -60,6 +67,10 @@ This script automates the process of updating the version and stage in the Wazuh
 - `CHANGELOG.md`
 - `VERSION.json`
 - `package.json`
+- `.github/workflows/5_builderpackage_notifications_plugin.yml`
+- `.github/workflows/5_builderprecompiled_base-dev-environment.yml` (only when not using `--set-as-main`)
+- `.github/workflows/dashboards-notifications-test-and-build-workflow.yml` (only when not using `--set-as-main`)
+- `.github/workflows/dashboards-notifications-test-and-build-workflow-prod-docker-linux.yml` (only when not using `--set-as-main`)
 
 ### Log
 

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -13,6 +13,8 @@ VERSION_FILE="${REPO_PATH}/VERSION.json"
 VERSION=""
 REVISION="00"
 TAG=false
+set_as_main=""
+skip_urls="no"
 CURRENT_VERSION=""
 
 # Function to log messages
@@ -24,7 +26,7 @@ log() {
 
 # Function to show usage
 usage() {
-  echo "Usage: $0 --version VERSION --stage STAGE [--help]"
+  echo "Usage: $0 --version VERSION --stage STAGE [--tag] [--set-as-main] [--help]"
   echo ""
   echo "Parameters:"
   echo "  --version VERSION   Specify the version (e.g., 4.6.0)"
@@ -32,6 +34,7 @@ usage() {
   echo "  --stage STAGE       Specify the stage (e.g., alpha0, beta1, rc2, etc.)"
   echo "                      Required if --tag is not used"
   echo "  --tag               Generate a tag"
+  echo "  --set-as-main       Keep branch references pointing to main"
   echo "  --help              Display this help message"
   echo ""
   echo "Example:"
@@ -205,6 +208,10 @@ parse_arguments() {
       TAG=true
       shift
       ;;
+    --set-as-main)
+      set_as_main="yes"
+      shift 1
+      ;;
     --help)
       usage
       exit 0
@@ -216,6 +223,12 @@ parse_arguments() {
       ;;
     esac
   done
+
+  if [[ -n "$set_as_main" ]]; then
+    skip_urls="yes"
+  else
+    skip_urls="no"
+  fi
 }
 
 # Function to validate input parameters
@@ -443,6 +456,41 @@ update_manual_build_workflow() {
   log "Updating $WAZUH_DASHBOARD_NOTIFICATIONS_WORKFLOW_FILE workflow..."
 }
 
+update_branch_reference_defaults() {
+  if [[ "$skip_urls" == "yes" ]]; then
+    log "skip_urls is yes (--set-as-main): leaving workflow branch defaults unchanged"
+    return 0
+  fi
+
+  local bump_string="$VERSION"
+  local files=(
+    "${REPO_PATH}/.github/workflows/5_builderprecompiled_base-dev-environment.yml"
+    "${REPO_PATH}/.github/workflows/dashboards-notifications-test-and-build-workflow.yml"
+    "${REPO_PATH}/.github/workflows/dashboards-notifications-test-and-build-workflow-prod-docker-linux.yml"
+  )
+  local f
+  for f in "${files[@]}"; do
+    if [ ! -f "$f" ]; then
+      log "WARNING: $f not found. Skipping main→${bump_string} default update."
+      continue
+    fi
+
+    log "Replacing branch refs main with ${bump_string} in $f (where applicable)"
+
+    sed_inplace "s/^\\([[:space:]]*default:[[:space:]]*\\)main\\([[:space:]]*\\)$/\\1${bump_string}\\2/" "$f"
+    sed_inplace "s/^\\([[:space:]]*default:[[:space:]]*'\\)main'\\([[:space:]]*\\)$/\\1${bump_string}'\\2/" "$f"
+    sed_inplace "s/^\\([[:space:]]*default:[[:space:]]*\"\\)main\"\\([[:space:]]*\\)$/\\1${bump_string}\"\\2/" "$f"
+
+    sed_inplace "s/^\\([[:space:]]*NOTIFICATIONS_PLUGIN_VERSION:[[:space:]]*\\)main\\([[:space:]]*\\)$/\\1${bump_string}\\2/" "$f"
+    sed_inplace "s/^\\([[:space:]]*NOTIFICATIONS_PLUGIN_VERSION:[[:space:]]*'\\)main'\\([[:space:]]*\\)$/\\1${bump_string}'\\2/" "$f"
+    sed_inplace "s/^\\([[:space:]]*NOTIFICATIONS_PLUGIN_VERSION:[[:space:]]*\"\\)main\"\\([[:space:]]*\\)$/\\1${bump_string}\"\\2/" "$f"
+
+    sed_inplace "s/^\\([[:space:]]*OPENSEARCH_DASHBOARDS_VERSION:[[:space:]]*\\)main\\([[:space:]]*\\)$/\\1${bump_string}\\2/" "$f"
+    sed_inplace "s/^\\([[:space:]]*OPENSEARCH_DASHBOARDS_VERSION:[[:space:]]*'\\)main'\\([[:space:]]*\\)$/\\1${bump_string}'\\2/" "$f"
+    sed_inplace "s/^\\([[:space:]]*OPENSEARCH_DASHBOARDS_VERSION:[[:space:]]*\"\\)main\"\\([[:space:]]*\\)$/\\1${bump_string}\"\\2/" "$f"
+  done
+}
+
 # --- Main Execution ---
 main() {
   # Initialize log file
@@ -471,6 +519,12 @@ main() {
   # Compare versions and determine revision
   compare_versions_and_set_revision
 
+  if [[ "$skip_urls" == "yes" ]]; then
+    log "Main branch mode enabled: version values will be updated and branch references will remain pointing to main."
+  else
+    log "Freeze mode enabled: version values and branch references will be updated."
+  fi
+
   # Start file modifications
   log "Starting file modifications..."
 
@@ -478,6 +532,7 @@ main() {
   update_package_json
   update_changelog
   update_manual_build_workflow
+  update_branch_reference_defaults
 
   log "File modifications completed."
   log "Repository bump completed successfully. Log file: $LOG_FILE"

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -464,9 +464,8 @@ update_branch_reference_defaults() {
 
   local bump_string="$VERSION"
   local files=(
+    "${REPO_PATH}/.github/workflows/5_builderpackage_notifications_plugin.yml"
     "${REPO_PATH}/.github/workflows/5_builderprecompiled_base-dev-environment.yml"
-    "${REPO_PATH}/.github/workflows/dashboards-notifications-test-and-build-workflow.yml"
-    "${REPO_PATH}/.github/workflows/dashboards-notifications-test-and-build-workflow-prod-docker-linux.yml"
   )
   local f
   for f in "${files[@]}"; do
@@ -478,16 +477,6 @@ update_branch_reference_defaults() {
     log "Replacing branch refs main with ${bump_string} in $f (where applicable)"
 
     sed_inplace "s/^\\([[:space:]]*default:[[:space:]]*\\)main\\([[:space:]]*\\)$/\\1${bump_string}\\2/" "$f"
-    sed_inplace "s/^\\([[:space:]]*default:[[:space:]]*'\\)main'\\([[:space:]]*\\)$/\\1${bump_string}'\\2/" "$f"
-    sed_inplace "s/^\\([[:space:]]*default:[[:space:]]*\"\\)main\"\\([[:space:]]*\\)$/\\1${bump_string}\"\\2/" "$f"
-
-    sed_inplace "s/^\\([[:space:]]*NOTIFICATIONS_PLUGIN_VERSION:[[:space:]]*\\)main\\([[:space:]]*\\)$/\\1${bump_string}\\2/" "$f"
-    sed_inplace "s/^\\([[:space:]]*NOTIFICATIONS_PLUGIN_VERSION:[[:space:]]*'\\)main'\\([[:space:]]*\\)$/\\1${bump_string}'\\2/" "$f"
-    sed_inplace "s/^\\([[:space:]]*NOTIFICATIONS_PLUGIN_VERSION:[[:space:]]*\"\\)main\"\\([[:space:]]*\\)$/\\1${bump_string}\"\\2/" "$f"
-
-    sed_inplace "s/^\\([[:space:]]*OPENSEARCH_DASHBOARDS_VERSION:[[:space:]]*\\)main\\([[:space:]]*\\)$/\\1${bump_string}\\2/" "$f"
-    sed_inplace "s/^\\([[:space:]]*OPENSEARCH_DASHBOARDS_VERSION:[[:space:]]*'\\)main'\\([[:space:]]*\\)$/\\1${bump_string}'\\2/" "$f"
-    sed_inplace "s/^\\([[:space:]]*OPENSEARCH_DASHBOARDS_VERSION:[[:space:]]*\"\\)main\"\\([[:space:]]*\\)$/\\1${bump_string}\"\\2/" "$f"
   done
 }
 


### PR DESCRIPTION
### Description
This PR adds support for the --set-as-main flag in this repository's bumper files as part of the two-step version bump flow from main.

If the --set-as-main flag is not set, it will update the references to main branch to the specified version, if its set, it will skip that step.

### Issues Resolved
- **Issue:** https://github.com/wazuh/wazuh-dashboard-notifications/issues/11

### Evidence:

<details><summary>Running: <code>./tools/repository_bumper.sh  --version 5.1.0 --stage alpha1 </code></summary>
<p>

```bash
wazuh-dashboard-notifications change/11-add-set-as-main-flag-support-to-repitory-bumper-wazuh-dashboard-notifications ❯ ./tools/repository_bumper.sh  --version 5.1.0 --stage alpha1
[2026-03-30 11:23:14] Starting repository bump process
[2026-03-30 11:23:14] Repository path: /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications
[2026-03-30 11:23:14] Version: 5.1.0
[2026-03-30 11:23:14] Stage: alpha1
[2026-03-30 11:23:14] Attempting to extract current version from /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/VERSION.json using sed...
[2026-03-30 11:23:14] Successfully extracted version using sed: 5.0.0
[2026-03-30 11:23:14] Current version detected in VERSION.json: 5.0.0
[2026-03-30 11:23:14] Attempting to extract current stage from /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/VERSION.json using sed...
[2026-03-30 11:23:14] Successfully extracted stage using sed: alpha0
[2026-03-30 11:23:14] Current stage detected in VERSION.json: alpha0
[2026-03-30 11:23:14] Attempting to extract current revision from /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/package.json using sed...
[2026-03-30 11:23:14] Successfully extracted revision using sed: 00
[2026-03-30 11:23:14] Current revision detected in package.json: 00
[2026-03-30 11:23:14] Default revision set to: 00
[2026-03-30 11:23:14] Comparing new version (5.1.0) with current version (5.0.0)...
[2026-03-30 11:23:14] Version check passed: New version (5.1.0) is greater than current version (5.0.0) (Minor increased).
[2026-03-30 11:23:14] Final revision determined: 00
[2026-03-30 11:23:14] Freeze mode enabled: version values and branch references will be updated.
[2026-03-30 11:23:14] Starting file modifications...
[2026-03-30 11:23:14] Processing /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/VERSION.json
[2026-03-30 11:23:14] Successfully updated /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/VERSION.json with new version: 5.1.0 and stage: alpha1
[2026-03-30 11:23:14] Processing /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/package.json
[2026-03-30 11:23:14] Attempting to update version to 5.1.0 within 'wazuh' object in /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/package.json
[2026-03-30 11:23:14] Successfully updated /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/package.json with new version: 5.1.0 and revision: 00
[2026-03-30 11:23:14] Updating CHANGELOG.md...
[2026-03-30 11:23:14] Attempting to extract .version from /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/package.json using sed (Note: This is fragile)
[2026-03-30 11:23:14] Detected OpenSearch Dashboards version for changelog: 3.5.0
[2026-03-30 11:23:14] No existing changelog entry for this version and OpenSearch Dashboards version. Inserting new entry.
[2026-03-30 11:23:14] CHANGELOG.md updated successfully.
[2026-03-30 11:23:14] Processing /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/.github/workflows/5_builderpackage_notifications_plugin.yml
[2026-03-30 11:23:14] Attempting to update default reference to 5.1.0 in /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/.github/workflows/5_builderpackage_notifications_plugin.yml
[2026-03-30 11:23:14] Successfully updated /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/.github/workflows/5_builderpackage_notifications_plugin.yml with new default reference: 5.1.0
[2026-03-30 11:23:14] Updating /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/.github/workflows/5_builderpackage_notifications_plugin.yml workflow...
[2026-03-30 11:23:14] Replacing branch refs main with 5.1.0 in /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/.github/workflows/5_builderprecompiled_base-dev-environment.yml (where applicable)
[2026-03-30 11:23:14] Replacing branch refs main with 5.1.0 in /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/.github/workflows/dashboards-notifications-test-and-build-workflow.yml (where applicable)
[2026-03-30 11:23:14] Replacing branch refs main with 5.1.0 in /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/.github/workflows/dashboards-notifications-test-and-build-workflow-prod-docker-linux.yml (where applicable)
[2026-03-30 11:23:14] File modifications completed.
[2026-03-30 11:23:14] Repository bump completed successfully. Log file: /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/tools/repository_bumper_2026-03-30_11-23-14-328.log

```

</p>
</details> 

<details><summary>Running: <code>./tools/repository_bumper.sh  --version 5.1.0 --stage alpha1 --set-as-main</code></summary>
<p>

```bash
wazuh-dashboard-notifications change/11-add-set-as-main-flag-support-to-repitory-bumper-wazuh-dashboard-notifications  ❯ ./tools/repository_bumper.sh  --version 5.1.0 --stage alpha1 --set-as-main
[2026-03-30 11:23:39] Starting repository bump process
[2026-03-30 11:23:39] Repository path: /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications
[2026-03-30 11:23:39] Version: 5.1.0
[2026-03-30 11:23:39] Stage: alpha1
[2026-03-30 11:23:39] Attempting to extract current version from /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/VERSION.json using sed...
[2026-03-30 11:23:39] Successfully extracted version using sed: 5.0.0
[2026-03-30 11:23:39] Current version detected in VERSION.json: 5.0.0
[2026-03-30 11:23:39] Attempting to extract current stage from /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/VERSION.json using sed...
[2026-03-30 11:23:39] Successfully extracted stage using sed: alpha0
[2026-03-30 11:23:39] Current stage detected in VERSION.json: alpha0
[2026-03-30 11:23:39] Attempting to extract current revision from /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/package.json using sed...
[2026-03-30 11:23:39] Successfully extracted revision using sed: 00
[2026-03-30 11:23:39] Current revision detected in package.json: 00
[2026-03-30 11:23:39] Default revision set to: 00
[2026-03-30 11:23:39] Comparing new version (5.1.0) with current version (5.0.0)...
[2026-03-30 11:23:39] Version check passed: New version (5.1.0) is greater than current version (5.0.0) (Minor increased).
[2026-03-30 11:23:39] Final revision determined: 00
[2026-03-30 11:23:39] Main branch mode enabled: version values will be updated and branch references will remain pointing to main.
[2026-03-30 11:23:39] Starting file modifications...
[2026-03-30 11:23:39] Processing /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/VERSION.json
[2026-03-30 11:23:39] Successfully updated /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/VERSION.json with new version: 5.1.0 and stage: alpha1
[2026-03-30 11:23:39] Processing /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/package.json
[2026-03-30 11:23:39] Attempting to update version to 5.1.0 within 'wazuh' object in /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/package.json
[2026-03-30 11:23:39] Successfully updated /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/package.json with new version: 5.1.0 and revision: 00
[2026-03-30 11:23:39] Updating CHANGELOG.md...
[2026-03-30 11:23:39] Attempting to extract .version from /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/package.json using sed (Note: This is fragile)
[2026-03-30 11:23:39] Detected OpenSearch Dashboards version for changelog: 3.5.0
[2026-03-30 11:23:39] No existing changelog entry for this version and OpenSearch Dashboards version. Inserting new entry.
[2026-03-30 11:23:39] CHANGELOG.md updated successfully.
[2026-03-30 11:23:39] Processing /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/.github/workflows/5_builderpackage_notifications_plugin.yml
[2026-03-30 11:23:39] Attempting to update default reference to 5.1.0 in /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/.github/workflows/5_builderpackage_notifications_plugin.yml
[2026-03-30 11:23:39] Successfully updated /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/.github/workflows/5_builderpackage_notifications_plugin.yml with new default reference: 5.1.0
[2026-03-30 11:23:39] Updating /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/.github/workflows/5_builderpackage_notifications_plugin.yml workflow...
[2026-03-30 11:23:39] skip_urls is yes (--set-as-main): leaving workflow branch defaults unchanged
[2026-03-30 11:23:39] File modifications completed.
[2026-03-30 11:23:39] Repository bump completed successfully. Log file: /home/runner/Documents/Wazuh/repos/wazuh-dashboard-notifications/tools/repository_bumper_2026-03-30_11-23-39-116.log

```

</p>
</details> 

### Testing
- Try running the commands specified in evidence and look at the output log created.

### Check List
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff