### PR TITLE
Enhance active response form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Wazuh dashboard notifications plugin will be document
 ### Added
 
 - Support for Wazuh 5.0.0
+- Added Active responses app [#7](https://github.com/wazuh/wazuh-dashboard-notifications/pull/7) [#18](https://github.com/wazuh/wazuh-dashboard-notifications/pull/18)
 
 ### Changed
 

--- a/public/pages/CreateChannelActiveResponse/CreateChannel.tsx
+++ b/public/pages/CreateChannelActiveResponse/CreateChannel.tsx
@@ -69,7 +69,7 @@ export function CreateChannel(props: CreateChannelsProps) {
   // Wazuh active response specific states
   const [executable, setExecutable] = useState('');
   const [extraArgs, setExtraArgs] = useState('');
-  const [location, setLocation] = useState('all');
+  const [location, setLocation] = useState('local');
   const [agentId, setAgentId] = useState('');
   const [activeResponseType, setActiveResponseType] = useState<'stateless' | 'stateful'>(DEFAULT_ACTIVE_RESPONSE_TYPE);
   const [statefulTimeout, setStatefulTimeout] = useState(DEFAULT_TIMEOUT);

--- a/public/pages/CreateChannelActiveResponse/CreateChannel.tsx
+++ b/public/pages/CreateChannelActiveResponse/CreateChannel.tsx
@@ -183,13 +183,18 @@ export function CreateChannel(props: CreateChannelsProps) {
             <EuiSpacer />
           </>
         )}
-
-        <ChannelNamePanel
-          name={name}
-          setName={setName}
-          description={description}
-          setDescription={setDescription}
-        />
+        <ContentPanel
+          bodyStyles={{ padding: 'initial' }}
+          title="Name and description"
+          titleSize="s"
+        >
+          <ChannelNamePanel
+            name={name}
+            setName={setName}
+            description={description}
+            setDescription={setDescription}
+          />
+        </ContentPanel>
 
         <EuiSpacer />
         <ContentPanel

--- a/public/pages/CreateChannelActiveResponse/__tests__/__snapshots__/ActiveResponseSettings.test.tsx.snap
+++ b/public/pages/CreateChannelActiveResponse/__tests__/__snapshots__/ActiveResponseSettings.test.tsx.snap
@@ -2,38 +2,395 @@
 
 exports[`<ChimeSettings /> spec renders the component 1`] = `
 <div
-  class="euiFormRow euiFormRow--compressed"
-  id="random_html_id-row"
   style="max-width: 700px;"
 >
   <div
-    class="euiFormRow__labelWrapper"
-  >
-    <label
-      aria-invalid="false"
-      class="euiFormLabel euiFormRow__label"
-      for="random_html_id"
-    >
-      Executable
-    </label>
-  </div>
-  <div
-    class="euiFormRow__fieldWrapper"
+    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
+    id="random_html_id-row"
   >
     <div
-      class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
+      class="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid="false"
+        class="euiFormLabel euiFormRow__label"
+        for="random_html_id"
+      >
+        Executable
+      </label>
+    </div>
+    <div
+      class="euiFormRow__fieldWrapper"
     >
       <div
-        class="euiFormControlLayout__childrenWrapper"
+        class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
       >
-        <input
-          class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
-          data-test-subj="create-channel-active-response-executable-name"
-          id="random_html_id"
-          placeholder="Executable"
-          type="text"
-          value="test.exe"
-        />
+        <div
+          class="euiFormControlLayout__childrenWrapper"
+        >
+          <input
+            class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
+            data-test-subj="create-channel-active-response-executable-name"
+            id="random_html_id"
+            placeholder="Executable"
+            type="text"
+            value="test.exe"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
+    id="random_html_id-row"
+  >
+    <div
+      class="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid="false"
+        class="euiFormLabel euiFormRow__label"
+        for="random_html_id"
+      >
+        <span>
+          Extra arguments - 
+          <i
+            style="font-weight: normal;"
+          >
+            optional
+          </i>
+        </span>
+      </label>
+    </div>
+    <div
+      class="euiFormRow__fieldWrapper"
+    >
+      <textarea
+        class="euiTextArea euiTextArea--resizeVertical euiTextArea--fullWidth euiTextArea--compressed"
+        data-test-subj="create-channel-active-response-extra-args"
+        id="random_html_id"
+        placeholder="Extra arguments"
+        rows="3"
+        style="height: 4.1rem;"
+      >
+        --test
+      </textarea>
+    </div>
+  </div>
+  <div
+    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
+    id="random_html_id-row"
+  >
+    <div
+      class="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid="false"
+        class="euiFormLabel euiFormRow__label"
+        for="random_html_id"
+      >
+        Type
+      </label>
+       
+      <span
+        class="euiToolTipAnchor"
+      >
+        <svg
+          aria-hidden="true"
+          aria-label="Info"
+          class="euiIcon euiIcon--medium euiIcon-isLoading"
+          focusable="true"
+          height="16"
+          role="img"
+          tabindex="0"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+          />
+        </svg>
+      </span>
+    </div>
+    <div
+      class="euiFormRow__fieldWrapper"
+    >
+      <div
+        class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiInputPopover--fullWidth euiSuperSelect"
+      >
+        <div
+          class="euiPopover__anchor"
+        >
+          <div>
+            <input
+              id="random_html_id"
+              type="hidden"
+              value="stateful"
+            />
+            <div
+              class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
+            >
+              <div
+                class="euiFormControlLayout__childrenWrapper"
+              >
+                <span
+                  class="euiScreenReaderOnly"
+                  id="random_html_id"
+                >
+                  Select an option: Stateful, is selected
+                </span>
+                <button
+                  aria-haspopup="true"
+                  aria-labelledby="random_html_id random_html_id"
+                  class="euiSuperSelectControl euiSuperSelectControl--fullWidth euiSuperSelectControl--compressed"
+                  data-test-subj="create-channel-active-response-type"
+                  type="button"
+                >
+                  Stateful
+                </button>
+                <div
+                  class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                >
+                  <span
+                    class="euiFormControlLayoutCustomIcon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                      focusable="false"
+                      height="16"
+                      role="img"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
+    id="random_html_id-row"
+  >
+    <div
+      class="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid="false"
+        class="euiFormLabel euiFormRow__label"
+        for="random_html_id"
+      >
+        Stateful timeout (seconds)
+      </label>
+       
+      <span
+        class="euiToolTipAnchor"
+      >
+        <svg
+          aria-hidden="true"
+          aria-label="Info"
+          class="euiIcon euiIcon--medium euiIcon-isLoading"
+          focusable="true"
+          height="16"
+          role="img"
+          tabindex="0"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+          />
+        </svg>
+      </span>
+    </div>
+    <div
+      class="euiFormRow__fieldWrapper"
+    >
+      <div
+        class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
+      >
+        <div
+          class="euiFormControlLayout__childrenWrapper"
+        >
+          <input
+            class="euiFieldNumber euiFieldNumber--fullWidth euiFieldNumber--compressed"
+            data-test-subj="create-channel-active-response-timeout"
+            id="random_html_id"
+            min="0"
+            placeholder="Timeout in seconds"
+            type="number"
+            value="60"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
+    id="random_html_id-row"
+  >
+    <div
+      class="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid="false"
+        class="euiFormLabel euiFormRow__label"
+        for="random_html_id"
+      >
+        Location
+      </label>
+       
+      <span
+        class="euiToolTipAnchor"
+      >
+        <svg
+          aria-hidden="true"
+          aria-label="Info"
+          class="euiIcon euiIcon--medium euiIcon-isLoading"
+          focusable="true"
+          height="16"
+          role="img"
+          tabindex="0"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+          />
+        </svg>
+      </span>
+    </div>
+    <div
+      class="euiFormRow__fieldWrapper"
+    >
+      <div
+        class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiInputPopover--fullWidth euiSuperSelect"
+      >
+        <div
+          class="euiPopover__anchor"
+        >
+          <div>
+            <input
+              id="random_html_id"
+              type="hidden"
+              value="defined-agent"
+            />
+            <div
+              class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
+            >
+              <div
+                class="euiFormControlLayout__childrenWrapper"
+              >
+                <span
+                  class="euiScreenReaderOnly"
+                  id="random_html_id"
+                >
+                  Select an option: Defined agent, is selected
+                </span>
+                <button
+                  aria-haspopup="true"
+                  aria-labelledby="random_html_id random_html_id"
+                  class="euiSuperSelectControl euiSuperSelectControl--fullWidth euiSuperSelectControl--compressed"
+                  data-test-subj="create-channel-active-response-location"
+                  type="button"
+                >
+                  Defined agent
+                </button>
+                <div
+                  class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                >
+                  <span
+                    class="euiFormControlLayoutCustomIcon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                      focusable="false"
+                      height="16"
+                      role="img"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
+    id="random_html_id-row"
+  >
+    <div
+      class="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid="false"
+        class="euiFormLabel euiFormRow__label"
+        for="random_html_id"
+      >
+        Agent ID
+      </label>
+       
+      <span
+        class="euiToolTipAnchor"
+      >
+        <svg
+          aria-hidden="true"
+          aria-label="Info"
+          class="euiIcon euiIcon--medium euiIcon-isLoading"
+          focusable="true"
+          height="16"
+          role="img"
+          tabindex="0"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+          />
+        </svg>
+      </span>
+    </div>
+    <div
+      class="euiFormRow__fieldWrapper"
+    >
+      <div
+        class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
+      >
+        <div
+          class="euiFormControlLayout__childrenWrapper"
+        >
+          <input
+            class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
+            data-test-subj="create-channel-active-response-agent-id"
+            id="random_html_id"
+            placeholder="Enter the agent ID"
+            type="text"
+            value="001"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -42,47 +399,410 @@ exports[`<ChimeSettings /> spec renders the component 1`] = `
 
 exports[`<ChimeSettings /> spec renders the component with error 1`] = `
 <div
-  class="euiFormRow euiFormRow--compressed"
-  id="random_html_id-row"
   style="max-width: 700px;"
 >
   <div
-    class="euiFormRow__labelWrapper"
-  >
-    <label
-      aria-invalid="true"
-      class="euiFormLabel euiFormRow__label euiFormLabel-isInvalid"
-      for="random_html_id"
-    >
-      Executable
-    </label>
-  </div>
-  <div
-    class="euiFormRow__fieldWrapper"
+    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
+    id="random_html_id-row"
   >
     <div
-      class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
+      class="euiFormRow__labelWrapper"
     >
-      <div
-        class="euiFormControlLayout__childrenWrapper"
+      <label
+        aria-invalid="true"
+        class="euiFormLabel euiFormRow__label euiFormLabel-isInvalid"
+        for="random_html_id"
       >
-        <input
-          aria-describedby="random_html_id-error-0"
-          class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
-          data-test-subj="create-channel-active-response-executable-name"
-          id="random_html_id"
-          placeholder="Executable"
-          type="text"
-          value=""
-        />
-      </div>
+        Executable
+      </label>
     </div>
     <div
-      aria-live="polite"
-      class="euiFormErrorText euiFormRow__text"
-      id="random_html_id-error-0"
+      class="euiFormRow__fieldWrapper"
     >
-      test error
+      <div
+        class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
+      >
+        <div
+          class="euiFormControlLayout__childrenWrapper"
+        >
+          <input
+            aria-describedby="random_html_id-error-0"
+            class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
+            data-test-subj="create-channel-active-response-executable-name"
+            id="random_html_id"
+            placeholder="Executable"
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        aria-live="polite"
+        class="euiFormErrorText euiFormRow__text"
+        id="random_html_id-error-0"
+      >
+        test error
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
+    id="random_html_id-row"
+  >
+    <div
+      class="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid="false"
+        class="euiFormLabel euiFormRow__label"
+        for="random_html_id"
+      >
+        <span>
+          Extra arguments - 
+          <i
+            style="font-weight: normal;"
+          >
+            optional
+          </i>
+        </span>
+      </label>
+    </div>
+    <div
+      class="euiFormRow__fieldWrapper"
+    >
+      <textarea
+        class="euiTextArea euiTextArea--resizeVertical euiTextArea--fullWidth euiTextArea--compressed"
+        data-test-subj="create-channel-active-response-extra-args"
+        id="random_html_id"
+        placeholder="Extra arguments"
+        rows="3"
+        style="height: 4.1rem;"
+      >
+        --test
+      </textarea>
+    </div>
+  </div>
+  <div
+    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
+    id="random_html_id-row"
+  >
+    <div
+      class="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid="false"
+        class="euiFormLabel euiFormRow__label"
+        for="random_html_id"
+      >
+        Type
+      </label>
+       
+      <span
+        class="euiToolTipAnchor"
+      >
+        <svg
+          aria-label="Info"
+          class="euiIcon euiIcon--medium"
+          focusable="true"
+          height="16"
+          role="img"
+          tabindex="0"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M8 14A6 6 0 1 1 8 2a6 6 0 0 1 0 12Zm0-1A5 5 0 1 0 8 3a5 5 0 0 0 0 10Zm-.186-1.065A.785.785 0 0 1 7 11.12c0-.48.34-.82.814-.82.475 0 .809.34.809.82 0 .475-.334.815-.809.815ZM5.9 6.317C5.96 5.168 6.755 4.4 8.048 4.4c1.218 0 2.091.759 2.091 1.8 0 .736-.36 1.304-1.03 1.707-.56.33-.717.56-.717 1.022v.305l-.1.1H7.47l-.1-.1v-.431c-.005-.646.302-1.104.987-1.514.527-.322.708-.59.708-1.047 0-.536-.416-.91-1.05-.91-.652 0-1.064.374-1.112.998l-.1.092H6l-.1-.105Z"
+          />
+        </svg>
+      </span>
+    </div>
+    <div
+      class="euiFormRow__fieldWrapper"
+    >
+      <div
+        class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiInputPopover--fullWidth euiSuperSelect"
+      >
+        <div
+          class="euiPopover__anchor"
+        >
+          <div>
+            <input
+              id="random_html_id"
+              type="hidden"
+              value="stateful"
+            />
+            <div
+              class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
+            >
+              <div
+                class="euiFormControlLayout__childrenWrapper"
+              >
+                <span
+                  class="euiScreenReaderOnly"
+                  id="random_html_id"
+                >
+                  Select an option: Stateful, is selected
+                </span>
+                <button
+                  aria-haspopup="true"
+                  aria-labelledby="random_html_id random_html_id"
+                  class="euiSuperSelectControl euiSuperSelectControl--fullWidth euiSuperSelectControl--compressed"
+                  data-test-subj="create-channel-active-response-type"
+                  type="button"
+                >
+                  Stateful
+                </button>
+                <div
+                  class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                >
+                  <span
+                    class="euiFormControlLayoutCustomIcon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                      focusable="false"
+                      height="16"
+                      role="img"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                        fill-rule="non-zero"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
+    id="random_html_id-row"
+  >
+    <div
+      class="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid="false"
+        class="euiFormLabel euiFormRow__label"
+        for="random_html_id"
+      >
+        Stateful timeout (seconds)
+      </label>
+       
+      <span
+        class="euiToolTipAnchor"
+      >
+        <svg
+          aria-label="Info"
+          class="euiIcon euiIcon--medium"
+          focusable="true"
+          height="16"
+          role="img"
+          tabindex="0"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M8 14A6 6 0 1 1 8 2a6 6 0 0 1 0 12Zm0-1A5 5 0 1 0 8 3a5 5 0 0 0 0 10Zm-.186-1.065A.785.785 0 0 1 7 11.12c0-.48.34-.82.814-.82.475 0 .809.34.809.82 0 .475-.334.815-.809.815ZM5.9 6.317C5.96 5.168 6.755 4.4 8.048 4.4c1.218 0 2.091.759 2.091 1.8 0 .736-.36 1.304-1.03 1.707-.56.33-.717.56-.717 1.022v.305l-.1.1H7.47l-.1-.1v-.431c-.005-.646.302-1.104.987-1.514.527-.322.708-.59.708-1.047 0-.536-.416-.91-1.05-.91-.652 0-1.064.374-1.112.998l-.1.092H6l-.1-.105Z"
+          />
+        </svg>
+      </span>
+    </div>
+    <div
+      class="euiFormRow__fieldWrapper"
+    >
+      <div
+        class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
+      >
+        <div
+          class="euiFormControlLayout__childrenWrapper"
+        >
+          <input
+            class="euiFieldNumber euiFieldNumber--fullWidth euiFieldNumber--compressed"
+            data-test-subj="create-channel-active-response-timeout"
+            id="random_html_id"
+            min="0"
+            placeholder="Timeout in seconds"
+            type="number"
+            value="60"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
+    id="random_html_id-row"
+  >
+    <div
+      class="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid="false"
+        class="euiFormLabel euiFormRow__label"
+        for="random_html_id"
+      >
+        Location
+      </label>
+       
+      <span
+        class="euiToolTipAnchor"
+      >
+        <svg
+          aria-label="Info"
+          class="euiIcon euiIcon--medium"
+          focusable="true"
+          height="16"
+          role="img"
+          tabindex="0"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M8 14A6 6 0 1 1 8 2a6 6 0 0 1 0 12Zm0-1A5 5 0 1 0 8 3a5 5 0 0 0 0 10Zm-.186-1.065A.785.785 0 0 1 7 11.12c0-.48.34-.82.814-.82.475 0 .809.34.809.82 0 .475-.334.815-.809.815ZM5.9 6.317C5.96 5.168 6.755 4.4 8.048 4.4c1.218 0 2.091.759 2.091 1.8 0 .736-.36 1.304-1.03 1.707-.56.33-.717.56-.717 1.022v.305l-.1.1H7.47l-.1-.1v-.431c-.005-.646.302-1.104.987-1.514.527-.322.708-.59.708-1.047 0-.536-.416-.91-1.05-.91-.652 0-1.064.374-1.112.998l-.1.092H6l-.1-.105Z"
+          />
+        </svg>
+      </span>
+    </div>
+    <div
+      class="euiFormRow__fieldWrapper"
+    >
+      <div
+        class="euiPopover euiPopover--anchorDownLeft euiPopover--displayBlock euiInputPopover euiInputPopover--fullWidth euiSuperSelect"
+      >
+        <div
+          class="euiPopover__anchor"
+        >
+          <div>
+            <input
+              id="random_html_id"
+              type="hidden"
+              value="defined-agent"
+            />
+            <div
+              class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
+            >
+              <div
+                class="euiFormControlLayout__childrenWrapper"
+              >
+                <span
+                  class="euiScreenReaderOnly"
+                  id="random_html_id"
+                >
+                  Select an option: Defined agent, is selected
+                </span>
+                <button
+                  aria-haspopup="true"
+                  aria-labelledby="random_html_id random_html_id"
+                  class="euiSuperSelectControl euiSuperSelectControl--fullWidth euiSuperSelectControl--compressed"
+                  data-test-subj="create-channel-active-response-location"
+                  type="button"
+                >
+                  Defined agent
+                </button>
+                <div
+                  class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                >
+                  <span
+                    class="euiFormControlLayoutCustomIcon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                      focusable="false"
+                      height="16"
+                      role="img"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                        fill-rule="non-zero"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
+    id="random_html_id-row"
+  >
+    <div
+      class="euiFormRow__labelWrapper"
+    >
+      <label
+        aria-invalid="true"
+        class="euiFormLabel euiFormRow__label euiFormLabel-isInvalid"
+        for="random_html_id"
+      >
+        Agent ID
+      </label>
+       
+      <span
+        class="euiToolTipAnchor"
+      >
+        <svg
+          aria-label="Info"
+          class="euiIcon euiIcon--medium"
+          focusable="true"
+          height="16"
+          role="img"
+          tabindex="0"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M8 14A6 6 0 1 1 8 2a6 6 0 0 1 0 12Zm0-1A5 5 0 1 0 8 3a5 5 0 0 0 0 10Zm-.186-1.065A.785.785 0 0 1 7 11.12c0-.48.34-.82.814-.82.475 0 .809.34.809.82 0 .475-.334.815-.809.815ZM5.9 6.317C5.96 5.168 6.755 4.4 8.048 4.4c1.218 0 2.091.759 2.091 1.8 0 .736-.36 1.304-1.03 1.707-.56.33-.717.56-.717 1.022v.305l-.1.1H7.47l-.1-.1v-.431c-.005-.646.302-1.104.987-1.514.527-.322.708-.59.708-1.047 0-.536-.416-.91-1.05-.91-.652 0-1.064.374-1.112.998l-.1.092H6l-.1-.105Z"
+          />
+        </svg>
+      </span>
+    </div>
+    <div
+      class="euiFormRow__fieldWrapper"
+    >
+      <div
+        class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
+      >
+        <div
+          class="euiFormControlLayout__childrenWrapper"
+        >
+          <input
+            aria-describedby="random_html_id-error-0"
+            class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
+            data-test-subj="create-channel-active-response-agent-id"
+            id="random_html_id"
+            placeholder="Enter the agent ID"
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        aria-live="polite"
+        class="euiFormErrorText euiFormRow__text"
+        id="random_html_id-error-0"
+      >
+        test error
+      </div>
     </div>
   </div>
 </div>

--- a/public/pages/CreateChannelActiveResponse/__tests__/__snapshots__/ChannelNamePanel.test.tsx.snap
+++ b/public/pages/CreateChannelActiveResponse/__tests__/__snapshots__/ChannelNamePanel.test.tsx.snap
@@ -2,106 +2,85 @@
 
 exports[`<ChannelNamePanel/> spec renders errors 1`] = `
 <div
-  class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+  style="max-width: 700px;"
 >
   <div
-    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
-    style="padding: 0px 0px;"
+    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
+    id="random_html_id-row"
   >
     <div
-      class="euiFlexItem"
+      class="euiFormRow__labelWrapper"
     >
-      <h2
-        class="euiTitle euiTitle--small"
+      <label
+        aria-invalid="true"
+        class="euiFormLabel euiFormRow__label euiFormLabel-isInvalid"
+        for="random_html_id"
       >
-        Name and description
-      </h2>
+        Name
+      </label>
+    </div>
+    <div
+      class="euiFormRow__fieldWrapper"
+    >
+      <div
+        class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
+      >
+        <div
+          class="euiFormControlLayout__childrenWrapper"
+        >
+          <input
+            aria-describedby="random_html_id-error-0"
+            class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
+            data-test-subj="create-channel-name-input"
+            id="random_html_id"
+            placeholder="Enter active response name"
+            type="text"
+            value="test"
+          />
+        </div>
+      </div>
+      <div
+        aria-live="polite"
+        class="euiFormErrorText euiFormRow__text"
+        id="random_html_id-error-0"
+      >
+        test error
+      </div>
     </div>
   </div>
-  <hr
-    class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginSmall"
-  />
   <div
-    style="padding: initial;"
+    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
+    id="random_html_id-row"
   >
     <div
-      class="euiFormRow euiFormRow--compressed"
-      id="random_html_id-row"
+      class="euiFormRow__labelWrapper"
     >
-      <div
-        class="euiFormRow__labelWrapper"
+      <label
+        class="euiFormLabel euiFormRow__label"
+        for="random_html_id"
       >
-        <label
-          aria-invalid="true"
-          class="euiFormLabel euiFormRow__label euiFormLabel-isInvalid"
-          for="random_html_id"
-        >
-          Name
-        </label>
-      </div>
-      <div
-        class="euiFormRow__fieldWrapper"
-      >
-        <div
-          class="euiFormControlLayout euiFormControlLayout--compressed"
-        >
-          <div
-            class="euiFormControlLayout__childrenWrapper"
+        <span>
+          Description - 
+          <i
+            style="font-weight: normal;"
           >
-            <input
-              aria-describedby="random_html_id-error-0"
-              class="euiFieldText euiFieldText--compressed"
-              data-test-subj="create-channel-name-input"
-              id="random_html_id"
-              placeholder="Enter active response name"
-              type="text"
-              value="test"
-            />
-          </div>
-        </div>
-        <div
-          aria-live="polite"
-          class="euiFormErrorText euiFormRow__text"
-          id="random_html_id-error-0"
-        >
-          test error
-        </div>
-      </div>
+            optional
+          </i>
+        </span>
+      </label>
     </div>
     <div
-      class="euiFormRow euiFormRow--compressed"
-      id="random_html_id-row"
+      class="euiFormRow__fieldWrapper"
     >
-      <div
-        class="euiFormRow__labelWrapper"
+      <textarea
+        class="euiTextArea euiTextArea--resizeVertical euiTextArea--fullWidth euiTextArea--compressed"
+        data-test-subj="create-channel-description-input"
+        placeholder="What is the purpose of this active response?"
+        rows="3"
+        style="height: 4.1rem;"
       >
-        <label
-          class="euiFormLabel euiFormRow__label"
-          for="random_html_id"
-        >
-          <span>
-            Description - 
-            <i
-              style="font-weight: normal;"
-            >
-              optional
-            </i>
-          </span>
-        </label>
-      </div>
-      <div
-        class="euiFormRow__fieldWrapper"
-      >
-        <textarea
-          class="euiTextArea euiTextArea--resizeVertical euiTextArea--compressed"
-          data-test-subj="create-channel-description-input"
-          placeholder="What is the purpose of this active response?"
-          rows="3"
-          style="height: 4.1rem;"
-        >
-          test description
-        </textarea>
-      </div>
+        test description
+      </textarea>
     </div>
   </div>
 </div>
@@ -109,98 +88,77 @@ exports[`<ChannelNamePanel/> spec renders errors 1`] = `
 
 exports[`<ChannelNamePanel/> spec renders the component 1`] = `
 <div
-  class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+  style="max-width: 700px;"
 >
   <div
-    class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
-    style="padding: 0px 0px;"
+    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
+    id="random_html_id-row"
   >
     <div
-      class="euiFlexItem"
+      class="euiFormRow__labelWrapper"
     >
-      <h2
-        class="euiTitle euiTitle--small"
+      <label
+        aria-invalid="false"
+        class="euiFormLabel euiFormRow__label"
+        for="random_html_id"
       >
-        Name and description
-      </h2>
+        Name
+      </label>
     </div>
-  </div>
-  <hr
-    class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginSmall"
-  />
-  <div
-    style="padding: initial;"
-  >
     <div
-      class="euiFormRow euiFormRow--compressed"
-      id="random_html_id-row"
+      class="euiFormRow__fieldWrapper"
     >
       <div
-        class="euiFormRow__labelWrapper"
-      >
-        <label
-          aria-invalid="false"
-          class="euiFormLabel euiFormRow__label"
-          for="random_html_id"
-        >
-          Name
-        </label>
-      </div>
-      <div
-        class="euiFormRow__fieldWrapper"
+        class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
       >
         <div
-          class="euiFormControlLayout euiFormControlLayout--compressed"
+          class="euiFormControlLayout__childrenWrapper"
         >
-          <div
-            class="euiFormControlLayout__childrenWrapper"
-          >
-            <input
-              class="euiFieldText euiFieldText--compressed"
-              data-test-subj="create-channel-name-input"
-              id="random_html_id"
-              placeholder="Enter active response name"
-              type="text"
-              value="test"
-            />
-          </div>
+          <input
+            class="euiFieldText euiFieldText--fullWidth euiFieldText--compressed"
+            data-test-subj="create-channel-name-input"
+            id="random_html_id"
+            placeholder="Enter active response name"
+            type="text"
+            value="test"
+          />
         </div>
       </div>
     </div>
+  </div>
+  <div
+    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
+    id="random_html_id-row"
+  >
     <div
-      class="euiFormRow euiFormRow--compressed"
-      id="random_html_id-row"
+      class="euiFormRow__labelWrapper"
     >
-      <div
-        class="euiFormRow__labelWrapper"
+      <label
+        class="euiFormLabel euiFormRow__label"
+        for="random_html_id"
       >
-        <label
-          class="euiFormLabel euiFormRow__label"
-          for="random_html_id"
-        >
-          <span>
-            Description - 
-            <i
-              style="font-weight: normal;"
-            >
-              optional
-            </i>
-          </span>
-        </label>
-      </div>
-      <div
-        class="euiFormRow__fieldWrapper"
+        <span>
+          Description - 
+          <i
+            style="font-weight: normal;"
+          >
+            optional
+          </i>
+        </span>
+      </label>
+    </div>
+    <div
+      class="euiFormRow__fieldWrapper"
+    >
+      <textarea
+        class="euiTextArea euiTextArea--resizeVertical euiTextArea--fullWidth euiTextArea--compressed"
+        data-test-subj="create-channel-description-input"
+        placeholder="What is the purpose of this active response?"
+        rows="3"
+        style="height: 4.1rem;"
       >
-        <textarea
-          class="euiTextArea euiTextArea--resizeVertical euiTextArea--compressed"
-          data-test-subj="create-channel-description-input"
-          placeholder="What is the purpose of this active response?"
-          rows="3"
-          style="height: 4.1rem;"
-        >
-          test description
-        </textarea>
-      </div>
+        test description
+      </textarea>
     </div>
   </div>
 </div>

--- a/public/pages/CreateChannelActiveResponse/components/ActiveResponseSettings.tsx
+++ b/public/pages/CreateChannelActiveResponse/components/ActiveResponseSettings.tsx
@@ -25,12 +25,14 @@ export function ActiveResponseSettings(props: ActiveResponseSettingsProps) {
   const context = useContext(CreateChannelContext)!;
 
   return (
-    <>
+    <div
+            style={{maxWidth: '700px'}}
+        >
         <EuiCompressedFormRow
             label="Executable"
-            style={{ maxWidth: '700px' }}
             error={context.inputErrors.executable.join(' ')}
             isInvalid={context.inputErrors.executable.length > 0}
+            fullWidth
         >
             <EuiCompressedFieldText
                 fullWidth
@@ -48,10 +50,14 @@ export function ActiveResponseSettings(props: ActiveResponseSettingsProps) {
             />
         </EuiCompressedFormRow>
         <EuiCompressedFormRow
-            label="Extra arguments"
-            style={{ maxWidth: '700px' }}
+            label={
+                <span>
+                    Extra arguments - <i style={{ fontWeight: 'normal' }}>optional</i>
+                </span>
+            }
             error={context.inputErrors.extraArgs.join(' ')}
             isInvalid={context.inputErrors.extraArgs.length > 0}
+            fullWidth
         >
             <EuiCompressedTextArea
                 style={{ height: '4.1rem' }}
@@ -62,6 +68,7 @@ export function ActiveResponseSettings(props: ActiveResponseSettingsProps) {
                 onChange={(e) => props.setAttribute('extraArgs', e.target.value)}
             />
         </EuiCompressedFormRow>
+        
         <EuiCompressedFormRow
             label="Type"
             labelAppend={
@@ -70,9 +77,9 @@ export function ActiveResponseSettings(props: ActiveResponseSettingsProps) {
                     position="right"
                 />
             }
-            style={{ maxWidth: '300px' }}
             error={context.inputErrors.type.join(' ')}
             isInvalid={context.inputErrors.type.length > 0}
+            fullWidth
         >
             <EuiCompressedSuperSelect
                 data-test-subj="create-channel-active-response-type"
@@ -82,6 +89,7 @@ export function ActiveResponseSettings(props: ActiveResponseSettingsProps) {
                 ]}
                 valueOfSelected={props.attributes.type}
                 onChange={(value) => props.setAttribute('type', value)}
+                fullWidth
             />
         </EuiCompressedFormRow>
         {
@@ -94,10 +102,11 @@ export function ActiveResponseSettings(props: ActiveResponseSettingsProps) {
                             position="right"
                         />
                     }
-                    style={{ maxWidth: '300px' }}
+                    
                     error={context.inputErrors.statefulTimeout.join(' ')}
                     isInvalid={context.inputErrors.statefulTimeout.length > 0}
-
+                    fullWidth
+                    
                 >
                     <EuiCompressedFieldNumber
                         data-test-subj="create-channel-active-response-timeout"
@@ -106,6 +115,7 @@ export function ActiveResponseSettings(props: ActiveResponseSettingsProps) {
                         onChange={(e) => props.setAttribute('statefulTimeout', Number(e.target.value))}
                         isInvalid={context.inputErrors.statefulTimeout.length > 0}
                         min={0}
+                        fullWidth
                     />
                 </EuiCompressedFormRow>
             )
@@ -118,9 +128,9 @@ export function ActiveResponseSettings(props: ActiveResponseSettingsProps) {
                     position="right"
                 />
             }
-            style={{ maxWidth: '300px' }}
             error={context.inputErrors.location.join(' ')}
             isInvalid={context.inputErrors.location.length > 0}
+            fullWidth
         >
             <EuiCompressedSuperSelect
                 data-test-subj="create-channel-active-response-location"
@@ -131,6 +141,7 @@ export function ActiveResponseSettings(props: ActiveResponseSettingsProps) {
                 ]}
                 valueOfSelected={props.attributes.location}
                 onChange={(value) => props.setAttribute('location', value)}
+                fullWidth
             />
         </EuiCompressedFormRow>
         {
@@ -143,9 +154,9 @@ export function ActiveResponseSettings(props: ActiveResponseSettingsProps) {
                             position="right"
                         />
                     }
-                    style={{ maxWidth: '300px' }}
                     error={context.inputErrors.agentId.join(' ')}
                     isInvalid={context.inputErrors.agentId.length > 0}
+                    fullWidth
                 >
                     <EuiCompressedFieldText
                         fullWidth
@@ -161,13 +172,9 @@ export function ActiveResponseSettings(props: ActiveResponseSettingsProps) {
                             });
                         }}
                     />
-
                 </EuiCompressedFormRow>
-
             )
         }
-               
-    </>
-    
+    </div>
   );
 }

--- a/public/pages/CreateChannelActiveResponse/components/ChannelNamePanel.tsx
+++ b/public/pages/CreateChannelActiveResponse/components/ChannelNamePanel.tsx
@@ -19,49 +19,47 @@ interface ChannelNamePanelProps {
 export function ChannelNamePanel(props: ChannelNamePanelProps) {
   const context = useContext(CreateChannelContext)!;
   return (
-    <>
-      <ContentPanel
-        bodyStyles={{ padding: 'initial' }}
-        title="Name and description"
-        titleSize="s"
+    <div style={{ maxWidth: '700px' }}>
+      <EuiCompressedFormRow
+        label="Name"
+        error={context.inputErrors.name.join(' ')}
+        isInvalid={context.inputErrors.name.length > 0}
+        fullWidth
       >
-        <EuiCompressedFormRow
-          label="Name"
-          error={context.inputErrors.name.join(' ')}
+        <EuiCompressedFieldText
+          data-test-subj="create-channel-name-input"
+          placeholder="Enter active response name"
+          value={props.name}
+          onChange={(e) => props.setName(e.target.value)}
           isInvalid={context.inputErrors.name.length > 0}
-        >
-          <EuiCompressedFieldText
-            data-test-subj="create-channel-name-input"
-            placeholder="Enter active response name"
-            value={props.name}
-            onChange={(e) => props.setName(e.target.value)}
-            isInvalid={context.inputErrors.name.length > 0}
-            onBlur={() => {
-              context.setInputErrors({
-                ...context.inputErrors,
-                name: validateChannelName(props.name),
-              });
-            }}
+          onBlur={() => {
+            context.setInputErrors({
+              ...context.inputErrors,
+              name: validateChannelName(props.name),
+            });
+          }}
+          fullWidth
+        />
+      </EuiCompressedFormRow>
+      <EuiCompressedFormRow
+        label={
+          <span>
+            Description - <i style={{ fontWeight: 'normal' }}>optional</i>
+          </span>
+        }
+        fullWidth
+      >
+        <>
+          <EuiCompressedTextArea
+            data-test-subj="create-channel-description-input"
+            placeholder="What is the purpose of this active response?"
+            style={{ height: '4.1rem' }}
+            value={props.description}
+            onChange={(e) => props.setDescription(e.target.value)}
+            fullWidth
           />
-        </EuiCompressedFormRow>
-        <EuiCompressedFormRow
-          label={
-            <span>
-              Description - <i style={{ fontWeight: 'normal' }}>optional</i>
-            </span>
-          }
-        >
-          <>
-            <EuiCompressedTextArea
-              data-test-subj="create-channel-description-input"
-              placeholder="What is the purpose of this active response?"
-              style={{ height: '4.1rem' }}
-              value={props.description}
-              onChange={(e) => props.setDescription(e.target.value)}
-            />
-          </>
-        </EuiCompressedFormRow>
-      </ContentPanel>
-    </>
+        </>
+      </EuiCompressedFormRow>
+    </div>
   );
 }


### PR DESCRIPTION
### Description
This pull request enhances the active response form.

Changes:
- set local as default location
- set same width for all the inputs
- add optional tag to extra arguments input

### Issues Resolved
#12

### Evidences
<img width="815" height="869" alt="image" src="https://github.com/user-attachments/assets/029e08f3-ebf9-466a-8d0f-8c1983e028bb" />

### Test

Legend:
:black_circle:: none
:green_circle:: pass
:yellow_circle:: warning
:red_circle:: fail
:white_circle:: not applicable

## UI

| Test | Chrome | Firefox | Safari |
| --- |  --- | --- | --- |
| Go to the active response form and ensure, the intput width is same for all them, the extra arguments has the optional text and the default value for the location is Local | :black_circle: | :black_circle: | :black_circle: |

**Details**
<details>
<summary>:black_circle: Go to the active response form and ensure, the intput width is same for all them, the extra arguments has the optional text and the default value for the location is Local</summary>

Chrome - :black_circle:

Firefox - :black_circle:

Safari - :black_circle:

</details>


### Check List
- [x] Commits are signed per the DCO using --signoff
