### PR TITLE
Changes default location and handles empty extraArgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Wazuh dashboard notifications plugin will be document
 ### Added
 
 - Support for Wazuh 5.0.0
+- Added Active Response functionality [#7](https://github.com/wazuh/wazuh-dashboard-notifications/pull/7) [#20](https://github.com/wazuh/wazuh-dashboard-notifications/pull/20)
 
 ### Changed
 

--- a/public/pages/CreateChannelActiveResponse/CreateChannel.tsx
+++ b/public/pages/CreateChannelActiveResponse/CreateChannel.tsx
@@ -206,7 +206,7 @@ export function CreateChannel(props: CreateChannelsProps) {
             attributes={{
               type: activeResponseType,
               executable,
-              extraArgs: extraArgs.trim() === '' ? null : extraArgs,
+              extraArgs,
               location,
               agentId,
               statefulTimeout,

--- a/public/pages/CreateChannelActiveResponse/CreateChannel.tsx
+++ b/public/pages/CreateChannelActiveResponse/CreateChannel.tsx
@@ -69,7 +69,7 @@ export function CreateChannel(props: CreateChannelsProps) {
   // Wazuh active response specific states
   const [executable, setExecutable] = useState('');
   const [extraArgs, setExtraArgs] = useState('');
-  const [location, setLocation] = useState('all');
+  const [location, setLocation] = useState('local');
   const [agentId, setAgentId] = useState('');
   const [activeResponseType, setActiveResponseType] = useState<'stateless' | 'stateful'>(DEFAULT_ACTIVE_RESPONSE_TYPE);
   const [statefulTimeout, setStatefulTimeout] = useState(DEFAULT_TIMEOUT);
@@ -118,7 +118,7 @@ export function CreateChannel(props: CreateChannelsProps) {
       setIsEnabled(response.is_enabled);
       setName(response.name);
       setDescription(response.description || '');
-      
+
       // Active response specific fields
       setActiveResponseType(response.active_response?.type || '');
       setExecutable(response.active_response?.executable || '');
@@ -201,7 +201,7 @@ export function CreateChannel(props: CreateChannelsProps) {
             attributes={{
               type: activeResponseType,
               executable,
-              extraArgs,
+              extraArgs: extraArgs.trim() === '' ? null : extraArgs,
               location,
               agentId,
               statefulTimeout,

--- a/public/pages/CreateChannelActiveResponse/utils/helper.ts
+++ b/public/pages/CreateChannelActiveResponse/utils/helper.ts
@@ -9,19 +9,18 @@ export const constructActiveResponseObject = ({
   extraArgs,
   location,
   agentId,
-  statefulTimeout
+  statefulTimeout,
 }: {
-  activeResponseType: string,
-  executable: string,
-  extraArgs: string,
-  location: string,
-  agentId: string,
-  statefulTimeout: number
+  activeResponseType: string;
+  executable: string;
+  extraArgs: string;
+  location: string;
+  agentId: string;
+  statefulTimeout: number;
 }) => {
   const activeResponseObject: any = {
     type: activeResponseType,
     executable: executable,
-    extra_args: extraArgs,
     location,
   };
 
@@ -33,5 +32,9 @@ export const constructActiveResponseObject = ({
     activeResponseObject.stateful_timeout = statefulTimeout;
   }
 
+  if (extraArgs.trim() !== '') {
+    activeResponseObject.extra_args = extraArgs;
+  }
+
   return activeResponseObject;
-}
+};


### PR DESCRIPTION
### Description

The default value for the location is changed when creating an active response, and if it is an empty string, a null value is returned

### Issues Resolved

#19 

### Snapshots

<img width="2028" height="1008" alt="image" src="https://github.com/user-attachments/assets/2dc791ac-9e9a-401c-b4bb-4880aec2e47b" />
<img width="1724" height="1344" alt="image" src="https://github.com/user-attachments/assets/98086625-5119-4c5d-9edc-a5cddd4b5023" />
<img width="1779" height="1346" alt="image" src="https://github.com/user-attachments/assets/6df0ec70-dcd5-4c12-b6a5-ad3ef0c0ea12" />


### Test

Try creating Active Responses using the empty and data placeholders; when the alert is generated, it should be null if it is empty and contain the data if it had any.
