### PR TITLE
Update GitHub Actions workflow to use environment variable for token

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ env.GH_TOKEN }}
 
       - name: Determine branch name
         id: vars


### PR DESCRIPTION
### Description
The repository bumper workflow (5_bumper_repository.yml) was checking out the repo with secrets.GITHUB_TOKEN, which does not have the workflows scope. Pushes that modify files under .github/workflows/ (for example during a version bump) are rejected by GitHub with an error about workflow permissions.

This change switches the actions/checkout step to use token: ${{ env.GH_TOKEN }}, which is set from CI_WAZUHCI_BUMPER_TOKEN and has the required permissions. The outdated comment that claimed the bumper token lacked the right scopes has been removed.

### Issues Resolved
https://github.com/wazuh/wazuh-dashboard-notifications/issues/28

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).