### PR TITLE
Fix bumper

### DIFF
--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -372,9 +372,15 @@ compare_versions_and_set_revision() {
         # Ensure CURRENT_REVISION is treated as a number (remove leading zeros for arithmetic if necessary, handle base 10)
         local current_revision_int=$((10#$current_revision_val))
         local new_revision_int=$((current_revision_int + 1))
-        # Format back to two digits with leading zero
-        REVISION=$(printf "%02d" "$new_revision_int")
-        log "Current revision: $current_revision_val. New revision set to: $REVISION"
+        if [ -n "$STAGE" ] && [ "$STAGE" != "$CURRENT_STAGE" ]; then
+          # Format back to two digits with leading zero
+          log "Incrementing revision."
+          REVISION=$(printf "%02d" "$new_revision_int")
+          log "Current revision: $current_revision_val. New revision set to: $REVISION"
+        else
+          REVISION=$(printf "%02d" "$current_revision_int")
+          log "Current revision: $current_revision_val."
+        fi
       fi
     fi
   fi
@@ -394,7 +400,7 @@ update_root_version_json() {
     fi
 
     # Update stage in VERSION.json
-    if [[ "$CURRENT_STAGE" != "$STAGE" ]]; then
+    if [ -n "$STAGE" ] && [[ "$CURRENT_STAGE" != "$STAGE" ]]; then
       sed_inplace "s/^[[:space:]]*\"stage\"[[:space:]]*:[[:space:]]*\"[^\"]*\"/  \"stage\": \"$STAGE\"/" "$VERSION_FILE"
       modified=true
     fi


### PR DESCRIPTION
### Description
This pull request fixes wrong editions on bumper for --tag flag.

### Issues Resolved
[#81](https://github.com/wazuh/wazuh-dashboard-notifications/issues/81)

### Evidence

```console
ferrjr@ferrjrubu:~/Escritorio/Wazuh/wazuh-dashboard-notifications$ bash tools/repository_bumper.sh --tag
[2026-06-10 12:00:57] Starting repository bump process
[2026-06-10 12:00:57] Repository path: /home/ferrjr/Escritorio/Wazuh/wazuh-dashboard-notifications
[2026-06-10 12:00:57] Version: 
[2026-06-10 12:00:57] Stage: 
[2026-06-10 12:00:57] Attempting to extract current version from /home/ferrjr/Escritorio/Wazuh/wazuh-dashboard-notifications/VERSION.json using sed...
[2026-06-10 12:00:57] Successfully extracted version using sed: 5.0.0
[2026-06-10 12:00:57] Current version detected in VERSION.json: 5.0.0
[2026-06-10 12:00:57] Attempting to extract current stage from /home/ferrjr/Escritorio/Wazuh/wazuh-dashboard-notifications/VERSION.json using sed...
[2026-06-10 12:00:57] Successfully extracted stage using sed: beta3
[2026-06-10 12:00:57] Current stage detected in VERSION.json: beta3
[2026-06-10 12:00:57] Attempting to extract current revision from /home/ferrjr/Escritorio/Wazuh/wazuh-dashboard-notifications/package.json using sed...
[2026-06-10 12:00:57] Successfully extracted revision using sed: 03
[2026-06-10 12:00:57] Current revision detected in package.json: 03
[2026-06-10 12:00:57] Default revision set to: 00
[2026-06-10 12:00:57] Comparing new version (5.0.0) with current version (5.0.0)...
[2026-06-10 12:00:57] New version (5.0.0) is identical to current version (5.0.0). Incrementing revision.
[2026-06-10 12:00:57] Attempting to extract current revision from /home/ferrjr/Escritorio/Wazuh/wazuh-dashboard-notifications/package.json using sed (Note: This is fragile)
[2026-06-10 12:00:57] Successfully extracted revision using sed: 03
[2026-06-10 12:00:57] Current revision: 03.
[2026-06-10 12:00:57] Final revision determined: 03
[2026-06-10 12:00:57] Freeze mode enabled: version values and branch references will be updated.
[2026-06-10 12:00:57] Starting file modifications...
[2026-06-10 12:00:57] Processing /home/ferrjr/Escritorio/Wazuh/wazuh-dashboard-notifications/VERSION.json
[2026-06-10 12:00:57] Processing /home/ferrjr/Escritorio/Wazuh/wazuh-dashboard-notifications/package.json
[2026-06-10 12:00:57] Updating CHANGELOG.md...
[2026-06-10 12:00:57] Attempting to extract .version from /home/ferrjr/Escritorio/Wazuh/wazuh-dashboard-notifications/package.json using sed (Note: This is fragile)
[2026-06-10 12:00:57] Detected OpenSearch Dashboards version for changelog: 3.6.0
[2026-06-10 12:00:57] Replacing branch refs main with v5.0.0 in /home/ferrjr/Escritorio/Wazuh/wazuh-dashboard-notifications/.github/workflows/5_builderpackage_notifications_plugin.yml (where applicable)
[2026-06-10 12:00:57] Replacing branch refs main with v5.0.0 in /home/ferrjr/Escritorio/Wazuh/wazuh-dashboard-notifications/.github/workflows/5_builderprecompiled_base-dev-environment.yml (where applicable)
[2026-06-10 12:00:57] File modifications completed.
[2026-06-10 12:00:57] Repository bump completed successfully. Log file: /home/ferrjr/Escritorio/Wazuh/wazuh-dashboard-notifications/tools/repository_bumper_2026-06-10_12-00-57-435.log
```

```diff
ferrjr@ferrjrubu:~/Escritorio/Wazuh/wazuh-dashboard-notifications$ git diff
diff --git a/.github/workflows/5_builderpackage_notifications_plugin.yml b/.github/workflows/5_builderpackage_notifications_plugin.yml
index 71534ca..534ac5b 100644
--- a/.github/workflows/5_builderpackage_notifications_plugin.yml
+++ b/.github/workflows/5_builderpackage_notifications_plugin.yml
@@ -22,13 +22,13 @@ on:
         required: true
         type: string
         description: Git reference (branch, tag, or commit SHA) to build from.
-        default: main
+        default: v5.0.0
   workflow_dispatch:
     inputs:
       reference:
         required: true
         type: string
-        default: main
+        default: v5.0.0
         description: Git reference (branch, tag, or commit SHA) to build from.
 
 jobs:
diff --git a/.github/workflows/5_builderprecompiled_base-dev-environment.yml b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
index 6a96116..caad020 100644
--- a/.github/workflows/5_builderprecompiled_base-dev-environment.yml
+++ b/.github/workflows/5_builderprecompiled_base-dev-environment.yml
@@ -6,7 +6,7 @@ on:
       reference:
         required: true
         type: string
-        default: main
+        default: v5.0.0
         description: Git reference (branch, tag, or commit SHA) to build from.
       command:
         required: true

```

### Test
With clean repo, run bash tools/repository_bumper.sh --tag, this should not change the stage in VERSION.JSON and revision in package.json. Use git diff to check it.

</details>

### Check List
- [x] Commits are signed per the DCO using --signoff
