### PR TITLE
Add shortcut to create an Alerting monitor in the Active responses app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the Wazuh dashboard notifications plugin will be document
 ### Added
 
 - Support for Wazuh 5.0.0
-- Added Active responses app [#7](https://github.com/wazuh/wazuh-dashboard-notifications/pull/7) [#18](https://github.com/wazuh/wazuh-dashboard-notifications/pull/18) [#20](https://github.com/wazuh/wazuh-dashboard-notifications/pull/20)
+- Added Active responses app [#7](https://github.com/wazuh/wazuh-dashboard-notifications/pull/7) [#18](https://github.com/wazuh/wazuh-dashboard-notifications/pull/18) [#20](https://github.com/wazuh/wazuh-dashboard-notifications/pull/20) [#95](https://github.com/wazuh/wazuh-dashboard-notifications/pull/95)
 
 ### Changed
 

--- a/public/pages/ActiveResponses/Channels.tsx
+++ b/public/pages/ActiveResponses/Channels.tsx
@@ -40,6 +40,7 @@ import { getErrorMessage } from '../../utils/helpers';
 import { DEFAULT_PAGE_SIZE_OPTIONS } from '../Notifications/utils/constants';
 import { ChannelActions } from './components/ChannelActions';
 import { ChannelControls } from './components/ChannelControls';
+import { MonitorsShortcut } from './components/MonitorsShortcut';
 import { ChannelFiltersType } from './types';
 import { DataSourceMenuProperties } from '../../services/DataSourceMenuContext';
 import MDSEnabledComponent, {
@@ -252,6 +253,9 @@ export class Channels extends MDSEnabledComponent<ChannelsProps, ChannelsState> 
         testId: 'createButton',
         controlType: 'button',
       } as TopNavControlButtonData,
+      {
+        renderComponent: <MonitorsShortcut />,
+      },
     ];
 
     const totalChannels = (
@@ -325,6 +329,9 @@ export class Channels extends MDSEnabledComponent<ChannelsProps, ChannelsState> 
                         Create active response
                       </EuiSmallButton>
                     ),
+                  },
+                  {
+                    component: <MonitorsShortcut />,
                   },
                 ]}
               />

--- a/public/pages/ActiveResponses/__tests__/Channels.test.tsx
+++ b/public/pages/ActiveResponses/__tests__/Channels.test.tsx
@@ -66,4 +66,29 @@ describe('<Channels/> spec', () => {
       )
     );
   });
+
+  it('renders the Monitors shortcut with an info popover', () => {
+    const notificationServiceMock = jest.fn() as any;
+    notificationServiceMock.notificationService = {
+      getChannels: jest.fn(async () => []),
+    };
+    const utils = render(
+      <MainContext.Provider value={mainStateMock}>
+        <CoreServicesContext.Provider value={coreServicesMock}>
+          <Channels
+            {...routerComponentPropsMock}
+            notificationService={notificationServiceMock}
+          />
+        </CoreServicesContext.Provider>
+      </MainContext.Provider>
+    );
+
+    // Shortcut button is present.
+    expect(utils.getByTestId('monitors-shortcut-button')).toBeTruthy();
+
+    // The info popover is closed until the icon is clicked.
+    expect(utils.queryByText('Active responses & monitors')).toBeNull();
+    fireEvent.click(utils.getByTestId('monitors-shortcut-info-button'));
+    expect(utils.getByText('Active responses & monitors')).toBeTruthy();
+  });
 });

--- a/public/pages/ActiveResponses/__tests__/MonitorsShortcut.test.tsx
+++ b/public/pages/ActiveResponses/__tests__/MonitorsShortcut.test.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright Wazuh Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { fireEvent, render } from '@testing-library/react';
+import React from 'react';
+import { MonitorsShortcut } from '../components/MonitorsShortcut';
+import { handleMonitorsLinkClick } from '../../../utils/helpers';
+
+jest.mock('../../../utils/helpers', () => ({
+  getMonitorsAppUrl: () => 'http://localhost/app/monitors#/monitors',
+  handleMonitorsLinkClick: jest.fn(),
+}));
+
+describe('<MonitorsShortcut/> spec', () => {
+  it('links the button to the Monitors app url', () => {
+    const utils = render(<MonitorsShortcut />);
+    const button = utils.getByTestId('monitors-shortcut-button');
+    expect(button.getAttribute('href')).toBe(
+      'http://localhost/app/monitors#/monitors'
+    );
+  });
+
+  it('soft-navigates instead of a full reload when the button is clicked', () => {
+    const utils = render(<MonitorsShortcut />);
+    fireEvent.click(utils.getByTestId('monitors-shortcut-button'));
+    expect(handleMonitorsLinkClick).toHaveBeenCalled();
+  });
+
+  it('opens the info popover explaining the relationship', () => {
+    const utils = render(<MonitorsShortcut />);
+
+    expect(utils.queryByText('Active responses & monitors')).toBeNull();
+    fireEvent.click(utils.getByTestId('monitors-shortcut-info-button'));
+
+    expect(utils.getByText('Active responses & monitors')).toBeTruthy();
+  });
+});

--- a/public/pages/ActiveResponses/__tests__/__snapshots__/Channels.test.tsx.snap
+++ b/public/pages/ActiveResponses/__tests__/__snapshots__/Channels.test.tsx.snap
@@ -94,6 +94,80 @@ exports[`<Channels/> spec renders the empty component 1`] = `
                 </span>
               </a>
             </div>
+            <div
+              class="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+              >
+                <div
+                  class="euiFlexItem euiFlexItem--flexGrowZero"
+                >
+                  <button
+                    class="euiButton euiButton--primary euiButton--small"
+                    data-test-subj="monitors-shortcut-button"
+                    type="button"
+                  >
+                    <span
+                      class="euiButtonContent euiButtonContent--iconRight euiButton__content"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                        />
+                      </svg>
+                      <span
+                        class="euiButton__text"
+                      >
+                        Manage Monitors
+                      </span>
+                    </span>
+                  </button>
+                </div>
+                <div
+                  class="euiFlexItem euiFlexItem--flexGrowZero"
+                >
+                  <div
+                    class="euiPopover euiPopover--anchorDownRight"
+                  >
+                    <div
+                      class="euiPopover__anchor"
+                    >
+                      <button
+                        aria-label="About active responses and monitors"
+                        class="euiButtonIcon euiButtonIcon--primary euiButtonIcon--empty euiButtonIcon--xSmall"
+                        data-test-subj="monitors-shortcut-info-button"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                          focusable="false"
+                          height="16"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/public/pages/ActiveResponses/components/MonitorsShortcut.tsx
+++ b/public/pages/ActiveResponses/components/MonitorsShortcut.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright Wazuh Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPopover,
+  EuiSmallButton,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+import React, { useState } from 'react';
+import { ALERTING_DOCUMENTATION_LINK } from '../../../utils/constants';
+import {
+  getMonitorsAppUrl,
+  handleMonitorsLinkClick,
+} from '../../../utils/helpers';
+
+/**
+ * Shortcut that links to the Alerting > Monitors page, with an info popover
+ * explaining the relationship between an active response and its monitor.
+ */
+export function MonitorsShortcut() {
+  const [infoPopoverOpen, setInfoPopoverOpen] = useState(false);
+
+  return (
+    <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
+      <EuiFlexItem grow={false}>
+        <EuiSmallButton
+          iconType="popout"
+          iconSide="right"
+          href={getMonitorsAppUrl()}
+          onClick={handleMonitorsLinkClick}
+          data-test-subj="monitors-shortcut-button"
+        >
+          Manage Monitors
+        </EuiSmallButton>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiPopover
+          button={
+            <EuiButtonIcon
+              iconType="iInCircle"
+              aria-label="About active responses and monitors"
+              onClick={() => setInfoPopoverOpen(!infoPopoverOpen)}
+              color="primary"
+              data-test-subj="monitors-shortcut-info-button"
+            />
+          }
+          isOpen={infoPopoverOpen}
+          closePopover={() => setInfoPopoverOpen(false)}
+          anchorPosition="downRight"
+        >
+          <div style={{ width: '300px' }}>
+            <EuiText size="s">
+              <strong>Active responses &amp; monitors</strong>
+            </EuiText>
+            <EuiSpacer size="s" />
+            <EuiText size="xs">
+              <p>
+                An active response is executed as an action of an Alerting
+                monitor. Open Monitors to create or edit the monitor that
+                triggers it.
+              </p>
+            </EuiText>
+            <EuiSpacer size="s" />
+          </div>
+        </EuiPopover>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}

--- a/public/pages/CreateChannelActiveResponse/CreateChannel.tsx
+++ b/public/pages/CreateChannelActiveResponse/CreateChannel.tsx
@@ -8,6 +8,7 @@ import {
   EuiSmallButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiLink,
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
@@ -23,7 +24,12 @@ import {
   ROUTES,
   setBreadcrumbsActiveResponse as setBreadcrumbs
 } from '../../utils/constants';
-import { getErrorMessage } from '../../utils/helpers';
+import {
+  getErrorMessage,
+  getMonitorsAppUrl,
+  handleMonitorsLinkClick,
+} from '../../utils/helpers';
+import ReactDOM from 'react-dom';
 import { ChannelNamePanel } from './components/ChannelNamePanel';
 import {
   constructActiveResponseObject,
@@ -249,10 +255,30 @@ export function CreateChannel(props: CreateChannelsProps) {
                   : servicesContext.notificationService.createConfig(config);
                 await request
                   .then((response) => {
-                    coreContext.notifications.toasts.addSuccess(
-                      `Active response ${name} successfully ${props.edit ? 'updated' : 'created'
-                      }.`
-                    );
+                    coreContext.notifications.toasts.addSuccess({
+                      title: `Active response ${name} successfully ${props.edit ? 'updated' : 'created'
+                    }.`,
+                      text: (element: HTMLElement) => {
+                        ReactDOM.render(
+                          <>
+                            <EuiText size="s">
+                              It runs as an action of an Alerting monitor.
+                              Create or edit a monitor to trigger it.
+                            </EuiText>
+                            <EuiSpacer size="s" />
+                            <EuiLink
+                              href={getMonitorsAppUrl()}
+                              onClick={handleMonitorsLinkClick}
+                            >
+                              Go to Monitors
+                            </EuiLink>
+                          </>,
+                          element
+                        );
+                        return () =>
+                          ReactDOM.unmountComponentAtNode(element);
+                      },
+                    });
                     setTimeout(() => {
                       (window.location.hash = prevURL);
                     }, SERVER_DELAY);

--- a/public/pages/CreateChannelActiveResponse/__tests__/CreateChannel.test.tsx
+++ b/public/pages/CreateChannelActiveResponse/__tests__/CreateChannel.test.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { MOCK_DATA, MOCK_DATA_ACTIVE_RESPONSE } from '../../../../test/mocks/mockData';
@@ -78,5 +78,43 @@ describe('<CreateChannel/> spec', () => {
     await waitFor(() => {
       expect(updateConfigSuccess).toBeCalled();
     });
+  });
+
+  it('shows an enriched success toast with a Monitors link on create', async () => {
+    const createConfig = jest.fn(async (config: any) => Promise.resolve());
+    const notificationServiceMockCreate = {
+      notificationService: { createConfig },
+    } as any;
+    const props = {
+      location: { search: '' },
+      match: { params: {} },
+    };
+    const utils = render(
+      <MainContext.Provider value={mainStateMock}>
+        <ServicesContext.Provider value={notificationServiceMockCreate}>
+          <CoreServicesContext.Provider value={coreServicesMock}>
+            <CreateChannel {...(props as RouteComponentProps<{ id: string }>)} />
+          </CoreServicesContext.Provider>
+        </ServicesContext.Provider>
+      </MainContext.Provider>
+    );
+
+    fireEvent.change(utils.getByTestId('create-channel-name-input'), {
+      target: { value: 'my-active-response' },
+    });
+    fireEvent.change(
+      utils.getByTestId('create-channel-active-response-executable-name'),
+      { target: { value: 'restart.sh' } }
+    );
+
+    utils.getByTestId('create-channel-create-button').click();
+
+    await waitFor(() => expect(createConfig).toBeCalled());
+    expect(coreServicesMock.notifications.toasts.addSuccess).toBeCalledWith(
+      expect.objectContaining({
+        title: expect.stringContaining('created'),
+        text: expect.anything(),
+      })
+    );
   });
 });

--- a/public/utils/helpers.ts
+++ b/public/utils/helpers.ts
@@ -5,6 +5,42 @@
 
 import moment from 'moment';
 import 'moment-timezone';
+import type { MouseEvent } from 'react';
+import { getApplication, getUseUpdatedUx } from '../services/utils/constants';
+
+const ALERTING_APP_ID = 'alerting';
+const MONITORS_APP_ID = 'monitors';
+const MONITORS_PATH = '#/monitors';
+
+export function getMonitorsAppUrl(): string {
+  try {
+    const app = getApplication();
+    return getUseUpdatedUx()
+      ? app.getUrlForApp(MONITORS_APP_ID, { path: MONITORS_PATH })
+      : app.getUrlForApp(ALERTING_APP_ID, { path: MONITORS_PATH });
+  } catch {
+    return '';
+  }
+}
+
+export function navigateToMonitorsApp(): void {
+  const app = getApplication();
+  if (getUseUpdatedUx()) {
+    app.navigateToApp(MONITORS_APP_ID, { path: MONITORS_PATH });
+  } else {
+    app.navigateToApp(ALERTING_APP_ID, { path: MONITORS_PATH });
+  }
+}
+
+export function handleMonitorsLinkClick(
+  event: MouseEvent<HTMLElement>
+): void {
+  if (event.metaKey || event.ctrlKey || event.shiftKey || event.button === 1) {
+    return; // let the browser handle open in new tab
+  }
+  event.preventDefault();
+  navigateToMonitorsApp();
+}
 
 export function getErrorMessage(err: any, defaultMessage?: string) {
   if (defaultMessage) return defaultMessage;


### PR DESCRIPTION
### Description
- Added shortcut to Monitors in Active Responses page.
- Improved success active response toast.

### Issues Resolved
- https://github.com/wazuh/wazuh-dashboard-notifications/issues/94

### Evidence

<img width="1465" height="749" alt="Screenshot 2026-06-26 at 14 03 34" src="https://github.com/user-attachments/assets/6bcdc527-7749-4989-9f45-28954709ad70" />

<img width="1462" height="752" alt="Screenshot 2026-06-26 at 14 03 57" src="https://github.com/user-attachments/assets/a5e1b7f4-60c5-4d86-9d90-1fbc51241013" />

### Test

- Go to Active Responses app:
  - Verify `Manage Monitors` button renders and redirects correctly.
  - Verify popover render correctly.
- Create or edit an active response:
  - Verify toast.  

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
