### PR TITLE
Improve description of the Active response table when it's empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the Wazuh dashboard notifications plugin will be document
 ### Added
 
 - Support for Wazuh 5.0.0
-- Added Active responses app [#7](https://github.com/wazuh/wazuh-dashboard-notifications/pull/7) [#18](https://github.com/wazuh/wazuh-dashboard-notifications/pull/18) [#20](https://github.com/wazuh/wazuh-dashboard-notifications/pull/20) [#95](https://github.com/wazuh/wazuh-dashboard-notifications/pull/95)
+- Added Active responses app [#7](https://github.com/wazuh/wazuh-dashboard-notifications/pull/7) [#18](https://github.com/wazuh/wazuh-dashboard-notifications/pull/18) [#20](https://github.com/wazuh/wazuh-dashboard-notifications/pull/20) [#95](https://github.com/wazuh/wazuh-dashboard-notifications/pull/95) [#98](https://github.com/wazuh/wazuh-dashboard-notifications/pull/98)
 
 ### Changed
 

--- a/public/pages/ActiveResponses/Channels.tsx
+++ b/public/pages/ActiveResponses/Channels.tsx
@@ -283,8 +283,8 @@ export class Channels extends MDSEnabledComponent<ChannelsProps, ChannelsState> 
       isSelectable={true}
       selection={selection}
       noItemsMessage={<EuiEmptyPrompt
-        title={<EuiText size="s"><h2>No active responses to display</h2></EuiText>}
-        body={<EuiText size="s">"To response to events, you will need to create an active response."</EuiText>}
+        title={<EuiText size="s"><h2>No active responses configured</h2></EuiText>}
+        body={<EuiText size="s">Active responses are not configured. Create one to automatically react to security events.</EuiText>}
         actions={<EuiSmallButton href={`#${ROUTES.ACTIVE_RESPONSE_CREATE}`}>
           Create active response
         </EuiSmallButton>} />}

--- a/public/pages/ActiveResponses/__tests__/__snapshots__/Channels.test.tsx.snap
+++ b/public/pages/ActiveResponses/__tests__/__snapshots__/Channels.test.tsx.snap
@@ -652,7 +652,7 @@ exports[`<Channels/> spec renders the empty component 1`] = `
                         class="euiText euiText--small euiTitle euiTitle--medium"
                       >
                         <h2>
-                          No active responses to display
+                          No active responses configured
                         </h2>
                       </div>
                       <span
@@ -667,7 +667,7 @@ exports[`<Channels/> spec renders the empty component 1`] = `
                           <div
                             class="euiText euiText--small"
                           >
-                            "To response to events, you will need to create an active response."
+                            Active responses are not configured. Create one to automatically react to security events.
                           </div>
                         </div>
                       </span>

--- a/public/pages/MainActiveResponses/__tests__/__snapshots__/Main.test.tsx.snap
+++ b/public/pages/MainActiveResponses/__tests__/__snapshots__/Main.test.tsx.snap
@@ -584,7 +584,7 @@ exports[`<Main /> spec renders the component 1`] = `
                             class="euiText euiText--small euiTitle euiTitle--medium"
                           >
                             <h2>
-                              No active responses to display
+                              No active responses configured
                             </h2>
                           </div>
                           <span
@@ -599,7 +599,7 @@ exports[`<Main /> spec renders the component 1`] = `
                               <div
                                 class="euiText euiText--small"
                               >
-                                "To response to events, you will need to create an active response."
+                                Active responses are not configured. Create one to automatically react to security events.
                               </div>
                             </div>
                           </span>


### PR DESCRIPTION
### Description
- Updated empty state copy for active responses.

### Issues Resolved
- https://github.com/wazuh/wazuh-dashboard-notifications/issues/97

### Evidence

<img width="1028" height="515" alt="image" src="https://github.com/user-attachments/assets/e4ff4dba-fef0-4ed3-974b-162b824f2f64" />

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
