### PR TITLE
Standardizes the Claude Code / AI-assisted development

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git branch:*)",
+      "Bash(git show:*)",
+      "Bash(git remote -v)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh run view:*)",
+      "Bash(gh run list:*)",
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(rg:*)",
+      "Bash(find:*)",
+      "Bash(yarn lint)",
+      "Bash(yarn lint:*)",
+      "Bash(yarn test:jest)",
+      "Bash(yarn test:jest:*)",
+      "Bash(yarn cypress:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/.claude/skills/analyze-dashboard-vuln/SKILL.md
+++ b/.claude/skills/analyze-dashboard-vuln/SKILL.md
@@ -11,7 +11,7 @@ Run in **two beats**: investigate and present findings for confirmation (Beat 1)
 
 Once a row is confirmed **affected** and the user wants it fixed, hand off to the **resolve-cve** skill for remediation.
 
-> **repo-specific (local environment):** the Wazuh dashboard repos sit side by side under the workspace root (on this machine `/home/asus/wazuh/`). This repo is `wazuh-dashboard-notifications`. Write scratch files and issue drafts to a git-ignored dir such as `tmp/vuln-issues/`.
+> **repo-specific (local environment):** the Wazuh dashboard repos sit side by side under the workspace root (the parent directory that contains the sibling dashboard checkouts). This repo is `wazuh-dashboard-notifications`. Write scratch files and issue drafts to a git-ignored dir such as `tmp/vuln-issues/`.
 
 ## Input
 

--- a/.claude/skills/analyze-dashboard-vuln/SKILL.md
+++ b/.claude/skills/analyze-dashboard-vuln/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: analyze-dashboard-vuln
+description: Analyze a Wazuh dashboard vulnerability row, decide whether the affected library is reachable in production, fill the sheet's CVSS-Overall→Notes columns, and draft a GitHub issue body. User-invoked. Use when triaging Artifactory CVE rows across the Wazuh dashboard repos, before remediation.
+---
+
+Analyze an Artifactory vulnerability against the Wazuh dashboard repos (and their upstream OpenSearch forks), then produce two things: the **sheet row fragment** (`CVSS Overall Score → Notes`) the user pastes back, and a **GitHub issue body** `.md` the user creates manually.
+
+The whole analysis turns on one **verdict**: is the affected library **reachable in the production runtime**, or only a dev/test/transitive dependency? That verdict is binary and drives every filled column.
+
+Run in **two beats**: investigate and present findings for confirmation (Beat 1), then — only on the user's "go" — write the artifacts (Beat 2). Never create the GitHub issue yourself; you only write its body to a file and print its title.
+
+Once a row is confirmed **affected** and the user wants it fixed, hand off to the **resolve-cve** skill for remediation.
+
+> **repo-specific (local environment):** the Wazuh dashboard repos sit side by side under the workspace root (on this machine `/home/asus/wazuh/`). This repo is `wazuh-dashboard-notifications`. Write scratch files and issue drafts to a git-ignored dir such as `tmp/vuln-issues/`.
+
+## Input
+
+The user pastes one or more tab-separated rows copied from the Artifactory vulnerabilities sheet. Columns through **CVSS Base Severity** are filled; `Tentative release` reads `Not evaluated` or blank, `CVSS Overall Score`/`Severity` are blank.
+
+**There is a separate sheet per shipped Wazuh version** (e.g. a 4.10.4 sheet, a 4.14.5 sheet). That version is the **scanned ref** — what to inspect to confirm presence. If the user hasn't said which sheet, **ask** before investigating. The same CVE often recurs across version sheets as separate rows.
+
+Relevant fields per row: **CVE ID**, **GHSA ID**, **Affected library**, **Path** (e.g. `/usr/share/wazuh-dashboard/plugins/reportsDashboards/yarn.lock`), **Affected library version**, **CVSS Vector**, **CVSS Base Score**, **CVSS Base Severity**.
+
+Group rows by **CVE** — one CVE produces **one** consolidated issue covering every affected repo, plus one row fragment per input row.
+
+## Beat 1 — Investigate and report
+
+1. **Parse & group.** Split rows by tab, group by CVE ID. For each row, map its `Path` plugin dir to a local repo via [the repo map](#repo-map).
+
+2. **Pick the refs.** Two refs matter and they are different things:
+
+   - **Scanned ref** = the sheet's Wazuh version. Inspect the release **tag `v<version>`** (e.g. `v4.10.4`); fall back to `origin/<version>`. **Never read the bare local branch** — local branches drift from origin and will silently disagree with the scan (a stale `4.10.4` showed 0 handlebars while `v4.10.4` had it). Always `git fetch` first if unsure.
+   - **Resolution refs** = where the finding gets fixed/removed: check `origin/5.0.0` and the `5.0.0`/`main` tags to find the release that resolves it (drives `Tentative release`).
+
+3. **Locate + classify (the verdict).** On the scanned ref:
+
+   - Read the repo's `yarn.lock` via `git show <ref>:yarn.lock`, confirm the library and version match the row.
+   - Trace why it is pulled in (`yarn why <lib>` in the repo, or follow the dependency chain in the lockfile). If **every** path to it is a `devDependency` (cypress, mocha, mochawesome, build tooling, etc.) → **not affected**. If **any** production dependency pulls it in → **affected**.
+   - Record the dependency chain as evidence.
+
+4. **Sweep for extras.** `grep -rl "<lib>" */**/yarn.lock` (or per-repo) across all local dashboard repos to find any repo carrying the library that the pasted rows did **not** include. Report extras so the user can decide whether to add sheet rows; the issue Description lists the union.
+
+5. **Upstream fix status (only if affected).** Our repos are forks of `opensearch-project/*` ([map](#repo-map)). Read upstream via GitHub (don't clone): check tags/branches and the lockfile at a tag (`gh api` or raw `yarn.lock`) to find whether a patched version exists and which OpenSearch release carries it. For dependencies that come straight from upstream's lockfile, link the exact upstream lockfile line as evidence.
+
+6. **Propose + pause.** Present a per-row table: library@version on the scanned ref, prod/dev chain, **verdict**, the resolution ref, proposed **Overall Score/Severity** ([scoring](#scoring)), proposed **Tentative release** with reasoning ([release rules](#tentative-release) — flag the version-mapping guess explicitly), and proposed **Notes**. List any swept extras. **Stop and ask the user to confirm** before Beat 2. (Skip this pause only if the user passed `--yolo`.)
+
+## Beat 2 — Produce artifacts (on confirmation)
+
+7. **Draft the issue body.** First dedup: `gh issue list --repo wazuh/internal-devel-requests --search "<CVE> in:title" --state all`. If one already exists, reuse its URL and skip drafting. Otherwise write the [full template](#issue-template) to a git-ignored scratch file `tmp/vuln-issues/<CVE>.md`, reasoning each impact section for this CVE in Wazuh's context and enumerating all affected repos in the Description.
+
+8. **Print the issue title + labels** for manual creation: title per [convention](#title-convention); labels `level/task`, `type/vulnerability`.
+
+9. **Emit row fragments.** One tab-separated line per input row, in input order, containing exactly `Overall Score → Notes`: `<score>\t<severity>\t<tentative>\t<ISSUE_URL>\t<notes>`. Leave the literal `<ISSUE_URL>` placeholder. Leave the `Origin` column untouched.
+
+## Scoring
+
+Binary, no intermediate environmental score:
+
+- **affected** → `Overall Score = Base Score`, `Overall Severity = Base Severity`.
+- **not affected** → `Overall Score = 0`, `Overall Severity = None`.
+
+## Tentative release
+
+This column tracks **the Wazuh release that resolves the finding** (the library is patched or removed) — it is **independent of the exploitability verdict**. A not-affected, dev-only finding still gets the resolving version if the library is bumped/removed there (e.g. handlebars is a non-exploitable devDependency yet its rows read `5.0.0`, because it's patched to 4.7.9 in 5.0.0).
+
+- **resolved in a known Wazuh release** → that version (e.g. `5.0.0`). Always a **Wazuh** version, never an OpenSearch one (Notes may reference the OpenSearch version).
+- **affected and unfixed anywhere upstream** → `No fix available yet`.
+- **not affected and nothing tracks a resolution** → `Not affected`.
+
+Version-mapping heuristic (**still firming up — surface the reasoning and let the user confirm**): fix/bump landing in OpenSearch `3.x` → Wazuh `5.0.0`; the `4.14.x` line tracks OpenSearch `~2.19.x`. Confirmed data point: handlebars patched `4.7.9` lands in `5.0.0`.
+
+## Notes
+
+Terse verdict justification, plus an evidence link when one exists. Patterns:
+
+- not affected → `It is a development sub-dependency, therefore it cannot be exploited.`
+- no fix → `OpenSearch <ver> still has the <lib> <ver> version, which is vulnerable. <upstream yarn.lock#Lxxxx>`
+- fixed → `Fixed in Wazuh <ver>` (or `Fixed in this pr <PR url>`).
+
+## Repo map
+
+Sheet `Path` plugin dir → local repo (under the workspace root) → upstream fork source:
+
+| Plugin dir in Path                               | Local repo                           | Upstream (`opensearch-project/…`)      |
+| ------------------------------------------------ | ------------------------------------ | -------------------------------------- |
+| `securityDashboards`                             | `wazuh-security-dashboards-plugin`   | `security-dashboards-plugin`           |
+| `alertingDashboards`                             | `wazuh-dashboard-alerting`           | `alerting-dashboards-plugin`           |
+| `notificationsDashboards`                        | `wazuh-dashboard-notifications`      | `dashboards-notifications`             |
+| `reportsDashboards`                              | `wazuh-dashboard-reporting`          | `dashboards-reporting`                 |
+| `securityAnalyticsDashboards`                    | `wazuh-dashboard-security-analytics` | `security-analytics-dashboards-plugin` |
+| `wazuh`, `wazuhCore`, `wazuhCheckUpdates`        | `wazuh-dashboard-plugins`            | — (Wazuh-owned)                        |
+| base app / `/usr/share/wazuh-dashboard/...` core | `wazuh-dashboard`                    | `OpenSearch-Dashboards`                |
+
+Other OpenSearch plugin dirs (`customImportMapDashboards`, `ganttChartDashboards`, `indexManagementDashboards`, …) may have no Wazuh fork — note that and treat upstream as the source.
+
+## Title convention
+
+`Artifactory wazuh-dashboard CVE-XXXX-XXXXX` — current issues use the umbrella `wazuh-dashboard` even for a single sub-repo path (matching the sheet's `Vulnerability` column, which is `wazuh-dashboard` for this whole sheet). The specific sub-repo and path go in the issue body, not the title.
+
+## Issue template
+
+Write this verbatim structure, filling each section for the specific CVE:
+
+```markdown
+# Description
+
+CVE or steps to reproduce.
+
+# Availability impact
+
+Provide a brief description/explanation of how the vulnerability can be used to cause network outages/downtime or impact emergency services.
+
+# Confidentiality impact
+
+Provide a brief description/explanation of how the vulnerability can be used for unauthorized monitoring/disclosure of proprietary/classified systems/information.
+
+# Integrity impact
+
+Provide a brief description/explanation of how the vulnerability can result in theft, destruction, modification or loss of private/sensitive data.
+
+# Exploitability
+
+Provide a brief description of the potential attack scenario, e.g. - how can the vulnerability be exploited?
+
+# Mitigation/Containment plan
+
+Provide details of any workarounds or containment actions that can be taken.
+```
+
+For a **not-affected** CVE, still produce all six sections (each stating no production impact and why), matching the `uuid`/`xmldom` precedent.

--- a/.claude/skills/check-standards/SKILL.md
+++ b/.claude/skills/check-standards/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: check-standards
+description: Run the same code-quality checks CI runs (Prettier format, ESLint, typecheck, and unit tests) over the current diff before pushing or marking a PR ready. Use before opening/updating a PR, when the user asks to verify standards, lint, format, or check that CI will pass.
+---
+
+# Check standards (mirror CI locally)
+
+Runs, over the **changed files only**, the same gates CI applies on Wazuh Dashboard
+PRs, so failures are caught before they burn CI minutes. Fix issues, then re-run
+until clean.
+
+The approach is generic; blocks marked **repo-specific** cover this repo's exact
+commands (test runner, lint, typecheck).
+
+## Workflow
+
+```
+- [ ] 1. Compute changed files vs the base branch
+- [ ] 2. Prettier --check (autofix with --write)
+- [ ] 3. ESLint (autofix with --fix)
+- [ ] 4. Typecheck
+- [ ] 5. Unit tests for the changed code
+- [ ] 6. Report pass/fail summary
+```
+
+### 1. Compute changed files
+
+Match how CI computes them (diff against the base branch, excluding deletions):
+
+```bash
+BASE=<version-branch>            # e.g. 5.0.0 — the PR base
+git fetch origin "$BASE"
+CHANGED=$(git diff --name-status --diff-filter=d "origin/$BASE"...HEAD | awk '{print $NF}')
+CODE=$(echo "$CHANGED" | grep -E '\.[jt]sx?$' || true)   # js/jsx/ts/tsx only
+echo "$CHANGED"
+```
+
+### 2. Prettier (format)
+
+Check the changed files the same way pre-commit (`.lintstagedrc`) would:
+
+```bash
+npx prettier $CHANGED --check --ignore-unknown
+# autofix:
+npx prettier $CHANGED --write --ignore-unknown
+```
+
+> **repo-specific (wazuh-dashboard-notifications):** this repo **has its own local
+> `.prettierrc`** (`es5` trailing commas, single quotes, 80-col) — Prettier
+> resolves it from the repo root, not the parent checkout. `.prettierignore` skips
+> `*.md` and `*.lock`, so don't expect those to be reformatted. A `.lintstagedrc`
+> runs `prettier --write` on staged files, but there is **no husky hook wired in
+> this repo** — run Prettier yourself.
+
+### 3. ESLint
+
+> **repo-specific (wazuh-dashboard-notifications):** ESLint config is `.eslintrc.js`
+> (extends `@elastic/eslint-config-kibana` + `plugin:@elastic/eui/recommended`; a
+> legacy YAML `.eslintrc` is also present), and the lint script runs through the
+> parent checkout. `yarn lint` runs **both ESLint and Stylelint**
+> (`node ../../scripts/eslint . && node ../../scripts/stylelint`). Run it from this
+> plugin's dir inside `wazuh-dashboard/plugins/<this-plugin>`. It enforces the
+> short SPDX **license header** on `.js`/`.ts`/`.tsx` files, so new files need the
+> `Copyright OpenSearch Contributors` / `SPDX-License-Identifier: Apache-2.0`
+> block.
+>
+> ```bash
+> yarn lint                     # ESLint + Stylelint over the whole plugin
+> node ../../scripts/eslint . --fix   # autofix ESLint
+> ```
+>
+> If you need to scope ESLint to changed files, `node ../../scripts/eslint $CODE`
+> works too (the `@elastic/eslint-import-resolver-kibana` resolver needs the parent
+> checkout's `node_modules`).
+
+### 4. Typecheck
+
+> **repo-specific (wazuh-dashboard-notifications):** there is **no `typecheck`
+> script**. `tsconfig.json` extends `../../tsconfig.json`, so run it from inside
+> the parent checkout:
+>
+> ```bash
+> ../../node_modules/.bin/tsc --noEmit -p tsconfig.json
+> ```
+
+### 5. Unit tests (changed code)
+
+> **repo-specific (wazuh-dashboard-notifications):** the test script is
+> **`yarn test:jest`** (it runs `TZ=UTC ../../node_modules/.bin/jest --config
+> ./test/jest.config.js` from inside the `wazuh-dashboard` checkout at
+> `plugins/<this-plugin>`). Bootstrap once (`yarn osd bootstrap` from the
+> `wazuh-dashboard` root), then:
+>
+> ```bash
+> yarn test:jest
+> ```
+>
+> Scope for speed with a path/pattern (`yarn test:jest <path>`). Refresh snapshots
+> only when the change intends to (`yarn test:jest -u`).
+
+Remember: unit tests are **colocated** (`*.test.ts` / `*.test.tsx`, typically in
+`__tests__/` folders next to the source, snapshots under `__snapshots__/`). New
+source files should ship with their colocated test.
+
+### 6. Report
+
+Summarize each gate as pass/fail; if anything failed, list the offending files and
+either fix them or explain what needs manual attention:
+
+```
+Prettier:  PASS
+ESLint:    FAIL (2 files) → public/components/Foo/Foo.tsx, server/routes/bar.ts
+Typecheck: PASS
+Jest:      PASS
+```
+
+Only report "ready for review" once every applicable gate passes.

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: create-pr
+description: Prepare a standardized pull request for a Wazuh Dashboard repository (verify version base branch, DCO sign-off, CHANGELOG entry, run local checks, and produce a ready-to-paste PR body with a pre-flight report). By default it prepares and hands off; it only runs `gh pr create` when explicitly asked. Use when the user asks to create, open, draft, or prepare a PR, or to get work ready for review.
+---
+
+# Prepare a Wazuh Dashboard pull request
+
+Standardized PR flow shared across all Wazuh Dashboard repositories. The body is
+generic; blocks marked **repo-specific** are the only parts to adjust when reusing
+this skill in another repo.
+
+**Default behavior: prepare and hand off.** Do the full pre-flight (steps 1–5) and
+output the ready-to-paste PR body plus a pre-flight report, so the human reviews
+and opens the PR. Only run `gh pr create` (step 6) when the user explicitly asks
+you to create/open/submit it.
+
+## Golden rules (do not skip)
+
+- **Open as Draft first.** CI is configured to skip Draft PRs, so iterate freely
+  while in Draft and only trigger CI when the work is validated.
+- **Base branch = the version branch the work started from** (e.g. `5.0.0`,
+  `6.0.0`), which is **not always `main`**. Never guess — confirm it.
+- **Every commit must be DCO-signed** (`git commit --signoff`).
+- **Validate locally before "Ready for review"** using the `check-standards` skill.
+- **English everywhere.** Describe the _why_, not just the _what_.
+- **Issues arrive as URLs** and may live in a different repo. Read them with
+  `gh issue view <url>` and classify the source (see below) — it changes both
+  "Issues Resolved" and the CHANGELOG.
+
+## Issue source: public vs internal
+
+Detect the source repo from the issue URL:
+
+- **Internal** — the URL/repo contains `internal-devel-request` (e.g.
+  `https://github.com/wazuh/internal-devel-requests/issues/5526`):
+  - PR "Issues Resolved": **leave empty** — never expose the internal link.
+  - CHANGELOG: **no entry** for internal-devel-requests issues.
+- **Public** — any other repo (e.g.
+  `https://github.com/wazuh/wazuh-dashboard-notifications/issues/123`):
+  - PR "Issues Resolved": `closes #<n>` (same repo) or `closes <issue-url>`
+    (another public repo).
+  - CHANGELOG: add an entry linking to the **issue** (see step 4).
+
+> **repo-specific:** the internal repo is `wazuh/internal-devel-requests`; match
+> it by the substring `internal-devel-request` in the URL.
+
+## Workflow
+
+Copy this checklist and track progress:
+
+```
+- [ ] 1. Confirm branch, base branch, and clean/committed state
+- [ ] 2. Verify commits are DCO-signed
+- [ ] 3. Run check-standards (lint + format + tests) and fix failures
+- [ ] 4. Add/confirm CHANGELOG entry (or justify the exception)
+- [ ] 5. Fill the PR template body + emit the pre-flight report  ← default stop here
+- [ ] 6. (Only if explicitly asked) Create the PR as Draft with gh
+- [ ] 7. (Only if explicitly asked) Mark Ready for review when everything passes
+```
+
+### 1. Confirm branch and base
+
+```bash
+git rev-parse --abbrev-ref HEAD        # current (feature) branch
+git log --oneline origin/main..HEAD 2>/dev/null | head   # sanity: what's new
+```
+
+Feature branch naming: `<type>/<issue#>-<kebab-description>` where `<type>` ∈
+`fix`, `bug`, `enhancement`, `feat`, `feature`, `change`, `doc`, `documentation`.
+
+To find the base version branch, list candidates and pick the one the branch
+diverged from; if ambiguous, **ask the user** rather than defaulting to `main`:
+
+```bash
+git branch -r | grep -E 'origin/(main|[0-9]+\.[0-9]+)'
+```
+
+### 2. Verify DCO sign-off
+
+```bash
+git log <base>..HEAD --format='%h %s%n%(trailers:key=Signed-off-by)'
+```
+
+Every commit needs a `Signed-off-by:` trailer. If missing, re-commit with
+`--signoff` (or `git rebase` adding sign-off) before continuing.
+
+### 3. Validate locally
+
+Invoke the **check-standards** skill (prettier + eslint on changed files, then
+`yarn test:jest`). Do not proceed to "Ready for review" until it passes.
+
+### 4. CHANGELOG entry
+
+Add one entry under the upcoming version, in the correct section
+(`Added` / `Changed` / `Fixed` / `Removed`). **The link points to the issue, not
+the PR.**
+
+> **repo-specific (wazuh-dashboard-notifications):** the changelog is
+> [`CHANGELOG.md`](../../../CHANGELOG.md) at the repo root, grouped under a
+> `## [v<x>]` heading with `### Added` / `### Changed` / `### Fixed` / `### Removed`
+> subsections. Group with an existing entry if the PR continues a previously merged
+> feature. (Many historical entries link to PRs; for new work, prefer the **issue**
+> link.)
+
+**Skip the entry entirely when:**
+
+- The issue is from **internal-devel-requests** (internal request → no changelog).
+- The PR is internal-tooling / docs-only / test-only / dependency-bump with no
+  user-facing impact — add the **`no changelog`** label to the PR instead.
+
+When unsure (and the issue is public), add an entry.
+
+### 5. Fill the PR body
+
+Fill the repository PR template **verbatim** (keep every heading and checklist
+item exactly).
+
+> **repo-specific (wazuh-dashboard-notifications):** this mirrors
+> [`.github/PULL_REQUEST_TEMPLATE.md`](../../../.github/PULL_REQUEST_TEMPLATE.md).
+> Read it first and keep this block in sync if the repo template changes. The
+> template has **no dedicated Evidence section** — put the screenshot/video
+> (REQUIRED for any UI change) and test notes under `### Description`.
+
+```markdown
+### Description
+[Describe what this change achieves]
+
+### Issues Resolved
+[List any issues this PR will resolve]
+
+### Check List
+- [ ] Commits are signed per the DCO using --signoff
+
+By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
+For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
+```
+
+Fill each section with real content; check the boxes that genuinely apply. For
+**Issues Resolved**: public issue → closing keyword (`closes`, `fixes`, `fix`)
+with `#<n>` or the full issue URL; **internal-devel-requests issue → leave the
+section empty** (see "Issue source" above).
+
+**Default deliverable — pre-flight report.** Unless the user asked you to create the
+PR, stop here and output the filled body plus this report for the human to act on:
+
+```
+PR pre-flight
+- Feature branch: <name>
+- Suggested base: <version-branch>   (confirm before creating)
+- Commits DCO-signed: yes / no (missing: <hashes>)
+- check-standards: PASS / FAIL (<summary>)
+- Issue source: public (<url>) / internal-devel-requests (link withheld)
+- CHANGELOG: entry added (links to issue) / not needed (internal / `no changelog`)
+- UI change: yes → evidence attached? / no
+- Command to open it: gh pr create --draft --base <base> ...
+```
+
+### 6. Create as Draft — only when explicitly asked
+
+```bash
+gh pr create --draft \
+  --base <version-branch> \
+  --title "<Imperative, capitalized subject>" \
+  --body "$(cat <<'EOF'
+### Description
+...
+EOF
+)"
+```
+
+### 7. Mark Ready for review — only when explicitly asked
+
+Only after check-standards passes and evidence is attached:
+
+```bash
+gh pr ready <pr-number-or-url>
+```
+
+Then move the linked issue to "Pending review". Prefer **squash merge** for
+single-purpose PRs.
+
+## Notes
+
+- Do not force-push shared branches; to address review feedback, push new commits
+  and re-request review.
+- Do not weaken auth/CSP/security and never commit secrets.

--- a/.claude/skills/develop-issue/SKILL.md
+++ b/.claude/skills/develop-issue/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: develop-issue
+description: Implement a GitHub issue end-to-end in a Wazuh Dashboard repo — plan, code following repo conventions, add colocated tests, validate with check-standards, add the CHANGELOG entry, and deliver a filled PR-template body (leaving Evidence/screenshot to the developer) WITHOUT opening the PR. Use when the user provides an issue to develop, implement, or work on.
+---
+
+# Develop an issue (issue → code → tests → delivery)
+
+Entry point for feature/bug work. Takes an issue, produces the change plus a
+ready-to-paste PR delivery, and hands off to the developer for the screenshot and
+the final PR creation. Chains the `check-standards` and `create-pr` skills.
+
+## Workflow
+
+Copy this checklist and track progress:
+
+```
+- [ ] 1. Plan from the issue (goal, acceptance criteria, affected layer)
+- [ ] 2. Implement, focused on the issue, respecting conventions
+- [ ] 3. Add/update colocated tests and run them
+- [ ] 4. Validate with check-standards; fix failures
+- [ ] 5. Add the CHANGELOG entry
+- [ ] 6. Deliver via create-pr (prepare mode) — do NOT open the PR
+```
+
+### 1. Plan
+
+Issues are normally shared as a **URL** and may live in a different repo. Read it
+first and classify the source:
+
+```bash
+gh issue view <issue-url>
+```
+
+- **Internal** — URL contains `internal-devel-request` (e.g.
+  `wazuh/internal-devel-requests`): the issue link is **not** exposed in the PR
+  ("Issues Resolved" stays empty) and there is **no CHANGELOG entry**.
+- **Public** — any other repo (e.g. `wazuh/wazuh-dashboard-notifications`): link
+  it in the PR and add a CHANGELOG entry pointing to the issue.
+
+Restate the issue's goal and acceptance criteria in your own words. Identify the
+affected **layer(s)** — `public` (browser/React), `server` (Node/routes/services),
+`common` (shared). Ask the user only if genuinely blocked; otherwise proceed with
+reasonable defaults.
+
+### 2. Implement
+
+Keep the change scoped to the issue. Respect the architecture and conventions in
+[`CLAUDE.md`](../../../CLAUDE.md):
+
+- Never import `server/` from `public/` or vice versa; put shared code in
+  `common/`. Cross-plugin: `public → other/public`, `server → other/server`,
+  preferably via `setup()`/`start()` contracts.
+- This is a fork of `opensearch-project/dashboards-notifications`: match the
+  **upstream filename convention** (PascalCase for components, e.g.
+  `ContentPanel`), TypeScript, English everywhere. New `.js`/`.ts`/`.tsx` files
+  need the short SPDX **license header** (`Copyright OpenSearch Contributors` /
+  `SPDX-License-Identifier: Apache-2.0`), enforced by ESLint. On upstream syncs,
+  Wazuh content wins.
+
+### 3. Tests (colocated)
+
+Add or update unit tests as `*.test.ts` / `*.test.tsx`, typically inside
+`__tests__/` folders **next to** the changed source (snapshots under
+`__snapshots__/`). New functionality must include testing.
+
+> **repo-specific (wazuh-dashboard-notifications):** this plugin's scripts run from
+> **inside the `wazuh-dashboard` checkout** at `plugins/<this-plugin>` (they
+> reference `../../node_modules/.bin/jest`). Bootstrap the platform once
+> (`yarn osd bootstrap` from the `wazuh-dashboard` root), then run
+> **`yarn test:jest`** here; refresh snapshots with `yarn test:jest -u`.
+
+### 4. Validate
+
+Run the **check-standards** skill (prettier + eslint + typecheck + tests over the
+diff). Fix everything it reports before delivering.
+
+### 5. CHANGELOG
+
+For **public** issues, add an entry under the upcoming version in
+[`CHANGELOG.md`](../../../CHANGELOG.md) (`Added` / `Changed` / `Fixed` /
+`Removed`), with the link pointing to the **issue** (not the PR). Skip the entry
+for **internal-devel-requests** issues, and for tooling/docs/test-only changes
+(use the `no changelog` label on the PR).
+
+### 6. Deliver (do NOT open the PR)
+
+Invoke **create-pr** in its default prepare-and-hand-off mode. Output:
+
+- The filled PR-template body, with the **`### Description`** completed, the
+  **`### Check List`** boxes that genuinely apply checked, and
+  **`### Issues Resolved` left empty** for internal-devel-requests issues (or
+  `closes #<n>` / issue URL for public ones), plus a screenshot/video reminder for
+  any UI change.
+- The pre-flight report (branch, suggested base, DCO status, check-standards
+  result, CHANGELOG status, and the `gh pr create` command to run when ready).
+
+End by reminding the developer to sign commits with `--signoff` and to add the
+screenshot before opening the PR.

--- a/.claude/skills/resolve-cve/SKILL.md
+++ b/.claude/skills/resolve-cve/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: resolve-cve
+description: Resolve a dependency CVE in the Wazuh Dashboard notifications plugin — confirm the vulnerable package is actually present and reachable, apply the least-invasive remediation (direct bump, lockfile dedupe, or scoped resolution), verify build/tests/audit, and hand off a prepared PR. Use when the user asks to fix or resolve a CVE / dependency vulnerability, or provides a CVE id or CVE issue URL.
+---
+
+# Resolve a dependency CVE
+
+Remediation flow for a dependency vulnerability. Pairs with **analyze-dashboard-vuln**
+(triage/verdict + issue drafting) — use that first if it's not yet confirmed the
+repo is affected. This skill assumes remediation is wanted.
+
+Optional input: a `CVE-XXXX-XXXXX` id or a CVE issue URL. Without one, look up open
+CVE issues and ask which to resolve.
+
+> **repo-specific (wazuh-dashboard-notifications):** this is a **single OSD plugin**
+> with **one `package.json` + one `yarn.lock`** at the repo root. Forced versions
+> live in the root `resolutions` block. It is developed **inside the
+> `wazuh-dashboard` checkout** at `plugins/<this-plugin>` and bootstrapped with the
+> platform (`yarn osd bootstrap` from the `wazuh-dashboard` root); its scripts
+> reference `../../node_modules/.bin/*`. See [`CLAUDE.md`](../../../CLAUDE.md).
+
+## Workflow
+
+```
+- [ ] 1. Identify the CVE (package, vulnerable range, safe version, severity)
+- [ ] 2. Verify presence + reachability in this plugin
+- [ ] 3. Remediate with the least-invasive strategy that works
+- [ ] 4. Verify (install + tests + audit; vulnerable version gone)
+- [ ] 5. Write a report to tmp/ and deliver via create-pr (prepare mode)
+```
+
+### 1. Identify
+
+Read the CVE. If given an issue URL: `gh issue view <url>`. Extract: affected
+package, vulnerable version range, recommended safe version, severity, and the
+GHSA if present. If you cannot confirm whether the repo is truly affected, run
+**analyze-dashboard-vuln** to get the reachability verdict before changing code.
+
+### 2. Verify presence + reachability
+
+Check the package is really installed and why:
+
+```bash
+grep -n '"<package>"' package.json           # declared as a direct dep?
+grep -n '<package>@' yarn.lock | head        # resolved versions in the lockfile
+yarn why <package>                            # dependency chain (run in the checkout)
+```
+
+If **every** path is a `devDependency` / build-test tool (cypress, jest, etc.) or
+a non-runtime transitive, the repo is effectively **not affected** — prefer
+documenting that (via analyze-dashboard-vuln) over forcing a change. Remediate
+only when a **runtime** path pulls the vulnerable version.
+
+### 3. Remediate (least invasive first)
+
+Back up first: `cp package.json package.json.bak && cp yarn.lock yarn.lock.bak`.
+Try strategies in order:
+
+- **A — Direct bump.** If the package is declared in `package.json`, set it to the
+  safe version and re-run `yarn`.
+- **B — Lockfile dedupe.** If it's transitive, remove its entries from `yarn.lock`
+  and re-run `yarn` so it regenerates to a patched version.
+- **C — Parent bump.** If a peer/parent constraint pins the old version, bump the
+  parent dependency, then retry B.
+- **D — Scoped resolution (last resort).** Add to the root `resolutions` using the
+  **narrowest** path (`"**/<parent>/<package>": "<safe>"`), never a global
+  override. Document why and which chain required it.
+
+Only change versions; never remove a required dependency; follow semver; never
+leave the repo in a broken state (restore the `.bak` files on failure).
+
+### 4. Verify
+
+> **repo-specific:** run from inside the `wazuh-dashboard` checkout at
+> `plugins/<this-plugin>`:
+>
+> ```bash
+> yarn                         # reinstall against the updated manifest/lockfile
+> yarn test:jest               # run the unit suite
+> ```
+>
+> Then confirm the vulnerable version is gone (`yarn why <package>` / grep the
+> lockfile) and check for new advisories (`yarn audit`).
+
+If any source code was touched, also run the **check-standards** skill. Remove the
+`.bak` files once verification passes.
+
+### 5. Report + deliver
+
+Write a short report to `tmp/cve-<id>.md` (strategy used, the changes,
+dependency-chain evidence, verification results — or, on failure, strategies tried
+and recommended manual steps). `tmp/` is git-ignored in this repo.
+
+Then invoke **create-pr** in its default prepare-and-hand-off mode. It applies the
+shared rules automatically:
+
+- Base = the version branch the work started from (not always `main`).
+- CVE issues usually live in **`internal-devel-requests`** → "Issues Resolved"
+  left empty and **no CHANGELOG entry**. If the CVE issue is public, use `closes`
+  and add a CHANGELOG entry (under `Fixed`/`Changed`) linking the **issue**.
+- Commits DCO-signed.
+
+Suggested PR title: `Fix <CVE-id>: bump <package> to <safe-version>`.
+
+## Success criteria
+
+1. No runtime path resolves the vulnerable version anymore.
+2. `yarn` install and `yarn test:jest` pass (in the checkout).
+3. No new advisories introduced for the resolved package.
+4. Report in `tmp/`, and a prepared PR (via create-pr) following repo conventions.

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,10 @@ yarn-error.log
 /.cypress/screenshots/
 /.cypress/videos/
 target
+
+# Claude Code: version the shared settings + skills, ignore personal overrides
+.claude/settings.local.json
+CLAUDE.local.md
+
+# Scratch dir for AI skill reports (CVE analysis/resolution, etc.)
+tmp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,16 @@ Enforced by tooling — run the linter/formatter, don't hand-format:
   `plugin:@elastic/eui/recommended` (a legacy YAML `.eslintrc` is also present). It
   enforces the short SPDX **license header** on every `.js`/`.ts`/`.tsx` file
   (`@osd/eslint/require-license-header`), so new files must start with:
+  
+  - Provided by Wazuh team (repository fork)
+  ```js
+  /*
+   * Copyright Wazuh Contributors
+   * SPDX-License-Identifier: Apache-2.0
+   */
+  ```
 
+  - Provided by upstream
   ```js
   /*
    * Copyright OpenSearch Contributors

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,198 @@
+# CLAUDE.md
+
+Wazuh-owned AI context for **`wazuh-dashboard-notifications`**. Keep it short: this
+file points to the source-of-truth docs instead of duplicating them. Read the
+linked doc before doing non-trivial work.
+
+## What this repo is
+
+A **single OpenSearch Dashboards (OSD) plugin** — the Wazuh fork of
+[`opensearch-project/dashboards-notifications`](https://github.com/opensearch-project/dashboards-notifications).
+It provides the **Notifications** UI in the Wazuh dashboard (notification channels
+& senders — email/Slack/webhook/etc. — and their related configuration). It is
+_not_ the platform — the platform is the sibling repo `wazuh-dashboard` (an OSD
+fork), into which this plugin is installed under its external `./plugins/`
+directory (alongside the plugins from `wazuh-dashboard-plugins`).
+
+- OSD id: `notificationsDashboards` (`opensearch_dashboards.json`); package name
+  `notifications-dashboards`; build zip `notifications-dashboards`. There is no
+  explicit `configPath` (it uses the default).
+- Versioning: OSD base in `package.json` → `opensearchDashboards.version` (e.g.
+  `3.6.0`) and `opensearch_dashboards.json` → `opensearchDashboardsVersion`;
+  Wazuh version in `VERSION.json` and `package.json` → `wazuh` (e.g. `5.0.0`,
+  revision `04`).
+- Node/Yarn: this plugin has **no own `.nvmrc`** — it uses the toolchain of the
+  `wazuh-dashboard` checkout it lives in (Node `22.22.0`, Yarn v1). Its scripts
+  reference the parent checkout (`../../scripts/*`, `../../node_modules/.bin/*`),
+  so it is developed **from inside `wazuh-dashboard/plugins/`**, not standalone.
+- Default branch `main`; work happens on version branches (`5.0.0`, `6.0.0`, …).
+
+## Architecture — read this before importing anything
+
+This is one self-contained plugin. Its code splits into layers that are bundled
+**separately**:
+
+- **`public/`** — runs in the **browser** (React, EUI/OUI, `core.http`). Uses
+  DOM/`window`. Holds `components/`, `pages/`, `services/`, `plugin.ts`,
+  `application.tsx`, `types.ts`.
+- **`server/`** — runs in **Node.js** (Hapi routes under `/api/`, services,
+  cluster clients). Uses `fs`, server context, secrets. Holds `routes/`,
+  `clusters/`, `utils/`, `plugin.ts`.
+- **`common/`** — **isomorphic** code shared by both: constants, helpers, types.
+  No DOM, no Node-only APIs. (`models/` holds shared interfaces too.)
+
+**Import rules (strict):**
+
+1. `public/` must **never** import from `server/`, and `server/` must **never**
+   import from `public/`. Putting Node code in a browser bundle (or vice-versa)
+   breaks the build/runtime.
+2. Both `public/` and `server/` may import from `common/`. Put anything shared in
+   `common/`.
+3. Cross-plugin access (e.g. to plugins from `wazuh-dashboard-plugins` or built-in
+   OSD plugins) goes **layer-to-layer** (`public → other/public`,
+   `server → other/server`) and only via a plugin's declared `setup()`/`start()`
+   contracts + `requiredPlugins`/`optionalPlugins` in `opensearch_dashboards.json`
+   — never reach into internal paths. This plugin requires `navigation`, `data`,
+   `opensearchDashboardsUtils` and optionally `share`, `managementOverview`,
+   `dataSource`, `dataSourceManagement`.
+
+### How `public/` and `server/` communicate
+
+They do **not** import each other — they talk over HTTP: `server/routes/*`
+register endpoints (`/api/...`, validated with `@osd/config-schema`) that delegate
+to services / cluster clients; `public/` calls those routes via OSD `core.http`.
+
+### Plugin lifecycle
+
+`setup(core, deps)` (register routes, saved objects, UI app, services) →
+`start(core, deps)` → `stop()`. Use `core.getStartServices()` in mount handlers
+instead of storing `start` references as fields.
+
+## Commands — run from inside the `wazuh-dashboard` checkout
+
+This plugin's scripts expect to run at `wazuh-dashboard/plugins/<this-plugin>`
+(they call `../../scripts/*` and `../../node_modules/.bin/*`). Bootstrap the
+platform first, then run per-plugin scripts here:
+
+```bash
+# From the wazuh-dashboard root (installs deps + builds internal packages):
+yarn osd bootstrap
+
+# From this plugin's dir (wazuh-dashboard/plugins/<this-plugin>):
+yarn lint                 # node ../../scripts/eslint . && node ../../scripts/stylelint (ESLint + Stylelint)
+node ../../scripts/eslint . --fix   # autofix ESLint
+yarn test:jest            # TZ=UTC jest --config ./test/jest.config.js
+yarn build                # plugin-helpers build → build/*.zip
+yarn cypress:run          # Cypress E2E (also: cypress:open)
+```
+
+Note the test script is **`yarn test:jest`** and lint runs **both ESLint and
+Stylelint**. There is **no** `format`, `lint:fix`, `typecheck`, or `knip` script
+here. This repo ships its own `.prettierrc` (`es5` trailing commas, single quotes,
+80-col) and `.prettierignore` (skips `*.md`, `*.lock`); a `.lintstagedrc` defines
+`prettier --write` on staged files, but **no husky hook is installed** — run
+Prettier yourself with `npx prettier <files> --write`. `tsconfig.json` extends
+`../../tsconfig.json`, so typecheck manually from the parent checkout:
+`../../node_modules/.bin/tsc --noEmit -p tsconfig.json`.
+
+### Running a local instance (Docker dev env)
+
+This plugin has **no dev environment of its own**. The canonical way to bring up a
+local Wazuh dashboard with this plugin — together with the other additional
+single-plugin forks (`wazuh-dashboard-reporting`,
+`wazuh-dashboard-security-analytics`, `wazuh-dashboard-alerting`) — is the Docker
+dev env **owned by `wazuh-dashboard-plugins`** (`docker/osd-dev`). Mount this repo
+into it with `-r`:
+
+```bash
+# from the sibling wazuh-dashboard-plugins checkout:
+cd ../wazuh-dashboard-plugins/docker/osd-dev
+./dev.sh up --base --server-local 0601 --indexer-local 0601 \
+  -r wazuh-dashboard-notifications \
+  -r wazuh-dashboard-reporting \
+  -r wazuh-dashboard-alerting
+```
+
+- `--base` — build/run the `wazuh-dashboard` platform from source (auto-detected
+  from the sibling checkout; or `--base /abs/path`).
+- `--server-local <tag>` — Wazuh server-local image tag (here `0601`).
+- `--indexer-local <tag>` — packaged indexer image tag.
+- `-r <repo>` — mount an external plugin repo (repeatable). Shorthand resolves the
+  repo by name under the sibling parent dir (e.g. `/home/asus/wazuh/`); or use
+  `-r name=/abs/path`. Point to the repository **ROOT**, not a subfolder.
+  `--all-forks` auto-discovers and mounts all sibling forks.
+
+Run `./dev.sh --help` for all flags. OSD comes up on `https://0.0.0.0:5601`
+(admin:admin).
+
+## Code conventions
+
+Enforced by tooling — run the linter/formatter, don't hand-format:
+
+- ESLint config is `.eslintrc.js` extending **`@elastic/eslint-config-kibana`** +
+  `plugin:@elastic/eui/recommended` (a legacy YAML `.eslintrc` is also present). It
+  enforces the short SPDX **license header** on every `.js`/`.ts`/`.tsx` file
+  (`@osd/eslint/require-license-header`), so new files must start with:
+
+  ```js
+  /*
+   * Copyright OpenSearch Contributors
+   * SPDX-License-Identifier: Apache-2.0
+   */
+  ```
+- **Filenames follow the upstream OpenSearch convention** (PascalCase for
+  components, e.g. `ContentPanel`, `PageHeader`; snake/camel elsewhere) — match
+  the surrounding upstream style when editing.
+- TypeScript-first; single quotes; semicolons; Prettier from the local
+  `.prettierrc` (`es5`, single quotes, 80-col).
+- English everywhere (code, comments, commits, docs).
+
+## Testing
+
+- **Unit tests are colocated** as `*.test.ts` / `*.test.tsx`, typically inside
+  `__tests__/` folders **next to** the code they cover (snapshots under
+  `__snapshots__/`). Run the whole suite with `yarn test:jest`; scope with a path
+  (`yarn test:jest <path>`). Refresh snapshots only when a change intends to
+  (`yarn test:jest -u`). When you add a source file, add its test beside it.
+- **Functional:** Cypress (`.cypress/`, `cypress.config.js`) via
+  `yarn cypress:run` / `yarn cypress:open`.
+
+## Git / PR workflow
+
+Shared Wazuh Dashboard conventions:
+
+- Branch names: `<type>/<issue#>-<kebab-desc>` (`fix/`, `enhancement/`, `feat/`,
+  `bug/`, `change/`, `doc/`). PR base = the target **version branch**, not always
+  `main` — confirm it.
+- **Sign commits** (DCO `--signoff`). Imperative, capitalized subject.
+- Open PRs as **Draft** (CI skips drafts); run lint + tests locally, then "Ready
+  for review". Squash merge for single-purpose PRs.
+- UI changes require a screenshot/video in the PR (the template is
+  [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md)).
+- **Changelog:** maintain [`CHANGELOG.md`](CHANGELOG.md) by hand for user-facing
+  changes; entries **link to the issue, not the PR**. No entry for
+  `internal-devel-requests` issues or tooling/docs/test-only PRs.
+- Issues arrive as URLs and may live in another repo. Issues from
+  `internal-devel-requests` are internal: don't expose their link in the PR
+  ("Issues Resolved" empty) and add no CHANGELOG entry.
+
+## Fork coexistence
+
+Upstream is `opensearch-project/dashboards-notifications`. On upstream syncs,
+**Wazuh content wins** and relevant upstream technical notes are folded into the
+sections above. Keep this file Wazuh-owned.
+
+## AI working rules
+
+- Before proposing a PR: `yarn lint` + `yarn test:jest` pass for the touched code.
+- Never weaken auth/CSP/security; never commit secrets or credentials.
+- Never force-push shared branches; never commit without DCO sign-off.
+- Respect the `public`/`server`/`common` import rules above — when in doubt, put
+  shared code in `common/`.
+
+## Source-of-truth docs
+
+- [`README.md`](README.md), [`CONTRIBUTING.md`](CONTRIBUTING.md),
+  [`SECURITY.md`](SECURITY.md).
+- Platform docs live in the sibling `wazuh-dashboard` repo
+  (`DEVELOPER_GUIDE.md`, `src/core/CONVENTIONS.md`, `src/core/TESTING.md`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ cd ../wazuh-dashboard-plugins/docker/osd-dev
 - `--server-local <tag>` — Wazuh server-local image tag (here `0601`).
 - `--indexer-local <tag>` — packaged indexer image tag.
 - `-r <repo>` — mount an external plugin repo (repeatable). Shorthand resolves the
-  repo by name under the sibling parent dir (e.g. `/home/asus/wazuh/`); or use
+  repo by name under the sibling parent dir (the parent of this checkout); or use
   `-r name=/abs/path`. Point to the repository **ROOT**, not a subfolder.
   `--all-forks` auto-discovers and mounts all sibling forks.
 


### PR DESCRIPTION
### Description

Standardizes the Claude Code / AI-assisted development configuration in this
repository, aligning it with `wazuh-dashboard-plugins` (the reference
implementation). It adds the Wazuh-owned AI context and the shared skill set so
contributors and AI agents follow the same conventions when developing issues,
checking standards, preparing PRs, and triaging/resolving dependency CVEs.

Docs/tooling only — **no functional or UI changes**:

- **`CLAUDE.md`**: concise, doc-linking AI context — identity as a single OSD
  plugin fork installed into `wazuh-dashboard/plugins/`, the `public`/`server`/
  `common` split and import rules, commands run from the parent OSD checkout, how
  to bring up a local instance via the plugins repo's `docker/osd-dev`
  (`./dev.sh up --base --server-local <tag> --indexer-local <tag> -r <repo>`),
  code conventions, git/PR workflow and fork coexistence.
- **`.claude/settings.json`**: versioned permission allowlist (safe reads +
  `yarn lint` / `yarn test:jest` / `yarn cypress`), adapted to this repo's scripts.
- **`.claude/skills/`**: 5 Agent Skills — `develop-issue`, `check-standards`,
  `create-pr`, `resolve-cve`, `analyze-dashboard-vuln` — with only the
  `repo-specific` blocks adapted to this plugin (upstream name, OSD id, commands).
- **`.gitignore`**: version the shared `.claude` config while ignoring personal
  overrides (`.claude/settings.local.json`, `CLAUDE.local.md`) and the `tmp/`
  scratch dir.

### Issues Resolved

<!-- Internal request: link intentionally omitted -->

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).