### PR TITLE
Change bumper_repository workflows merge type

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -212,7 +212,7 @@ jobs:
       - name: Merge pull request
         if: (inputs.revert != true && steps.check_changes.outputs.has_changes == 'true') || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
         run: |
-          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin
+          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --squash --admin
 
       - name: Show logs
         if: inputs.revert != true


### PR DESCRIPTION
## Description

`5_bumper_repository.yml` currently merges its generated bump PRs with `gh pr merge --merge --admin`, which creates a merge commit — inconsistent with this repo's squash-merge convention for single-purpose PRs. This PR switches it to `--squash --admin`.

Closes https://github.com/wazuh/wazuh-dashboard/issues/1459

## Proposed Changes

- `.github/workflows/5_bumper_repository.yml`: `gh pr merge ... --merge --admin` → `gh pr merge ... --squash --admin`.

### Results and Evidence

`git diff origin/5.0.0..HEAD` shows exactly 1 file changed, 1 line:

```diff
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -212,7 +212,7 @@
       - name: Merge pull request
         if: (inputs.revert != true && steps.check_changes.outputs.has_changes == 'true') || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
         run: |
-          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin
+          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --squash --admin
```

### Artifacts Affected

- `.github/workflows/5_bumper_repository.yml` (CI workflow, no runtime/build artifact)

### Configuration Changes

None (CI merge-strategy flag only).

### Documentation Updates

None.

### Tests Introduced

None. Non-executable CLI flag change in a GitHub Actions step — no unit-testable logic exists. Verified manually via direct diff/read inspection against `origin/5.0.0`.

### How to Test

1. Confirm `.github/workflows/5_bumper_repository.yml` passes `--squash --admin` (not `--merge --admin`).
2. (Optional, real effect only observable in CI) On the next bumper run on this branch, confirm the generated bump PR is merged via squash rather than a merge commit.

### Review Checklist

- [ ] All tests pass
  - [ ] `yarn test:jest` — N/A, no JS/TS changed
- [ ] New functionality includes testing. — N/A, no executable logic changed
- [ ] New functionality has been documented. — N/A
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md) — Skipped: internal CI tooling, no user-facing impact
- [x] Commits are signed per the DCO using --signoff
