### PR TITLE
Report skipped bumps in the repository bumper workflow

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -166,11 +166,14 @@ jobs:
           PR_NUMBER=$(gh pr list --head "$BUMP_BRANCH" --base "${{ github.ref_name }}" --state merged --json number --jq '.[0].number')
 
           if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" == "null" ]; then
-            echo "Error: The original PR for the bump was not found"
+            echo "The original PR for the bump was not found"
             echo "Searching merged PR from: $BUMP_BRANCH to ${{ github.ref_name }}"
-            exit 1
+            echo "pr_found=false" >> $GITHUB_OUTPUT
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
 
+          echo "pr_found=true" >> $GITHUB_OUTPUT
           echo "Original PR found: #$PR_NUMBER"
 
           MERGE_COMMIT=$(gh pr view $PR_NUMBER --json mergeCommit --jq '.mergeCommit.oid')
@@ -213,6 +216,17 @@ jobs:
         if: (inputs.revert != true && steps.check_changes.outputs.has_changes == 'true') || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
         run: |
           gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --squash --admin
+
+      - name: "Result: original bump pull request not found"
+        if: inputs.revert == true && steps.revert_step.outputs.pr_found == 'false'
+        run: echo "There is no original bump pull request to revert, nothing to do."
+
+      - name: "Result: no changes to commit"
+        if: >-
+          (inputs.revert != true && steps.check_changes.outputs.has_changes == 'false') ||
+          (inputs.revert == true && steps.revert_step.outputs.pr_found == 'true' &&
+          steps.revert_step.outputs.has_changes == 'false')
+        run: echo "The bump produced no changes, no pull request was created."
 
       - name: Show logs
         if: inputs.revert != true

--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -217,11 +217,11 @@ jobs:
         run: |
           gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --squash --admin
 
-      - name: "Result: original bump pull request not found"
+      - name: 'Result: original bump pull request not found'
         if: inputs.revert == true && steps.revert_step.outputs.pr_found == 'false'
         run: echo "There is no original bump pull request to revert, nothing to do."
 
-      - name: "Result: no changes to commit"
+      - name: 'Result: no changes to commit'
         if: >-
           (inputs.revert != true && steps.check_changes.outputs.has_changes == 'false') ||
           (inputs.revert == true && steps.revert_step.outputs.pr_found == 'true' &&


### PR DESCRIPTION
## Description

The release orchestration in `wazuh-qa-automation` now tells apart a repository bump that **failed** from a repository bump that **had nothing to do**, so a release is no longer blocked by a repository where the bump was a no-op. This repository's bumper workflow ended with a `failure` conclusion in two harmless situations, giving the orchestrator no way to know nothing was actually wrong.

Closes #124

## Proposed Changes

- `Revert references (Revert)` step: when the original bump pull request is not found, stop using `exit 1` and instead set `pr_found=false` / `has_changes=false` outputs and `exit 0`, so the run does not fail. Sets `pr_found=true` on the success path.
- Added two result-reporting steps, whose names are matched exactly (trimmed, case-insensitive) by the `wazuh-qa-automation` orchestrator:
  - `Result: original bump pull request not found`
  - `Result: no changes to commit`
- The existing `Check for changes` step already guarded the `Commit changes (Bump)` step against "nothing to commit" failures, and `Push changes` / `Create pull request` / `Merge pull request` were already conditioned on the same `has_changes` outputs, so no changes were needed there.

### Results and Evidence

<!-- Attach the links of the four validation runs described in the issue (revert with no original PR, bump with no changes, normal bump, normal revert) once available. -->

### Artifacts Affected

- `.github/workflows/5_bumper_repository.yml` (CI workflow only, no plugin artifacts affected).

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None (GitHub Actions workflow change; validated via the four workflow runs described in the issue).

## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
